### PR TITLE
Add Python 3.8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: python
 python:
   - "3.6"
   - "3.7"
+  - "3.8"
 before_install:
   - sudo apt-get install pandoc
   - sudo apt-get install build-essential

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Build Status](https://travis-ci.com/SeldonIO/alibi-detect.svg?branch=master)](https://travis-ci.com/SeldonIO/alibi-detect)
 [![Documentation Status](https://readthedocs.org/projects/alibi-detect/badge/?version=latest)](https://docs.seldon.io/projects/alibi-detect/en/latest/?badge=latest)
-![Python version](https://img.shields.io/badge/python-3.6%20%7C%203.7-blue.svg)
+![Python version](https://img.shields.io/badge/python-3.6%20%7C%203.7%20%7C%203.8-blue.svg)
 [![PyPI version](https://badge.fury.io/py/alibi-detect.svg)](https://badge.fury.io/py/alibi-detect)
 ![GitHub Licence](https://img.shields.io/github/license/seldonio/alibi-detect.svg)
 [![Slack channel](https://img.shields.io/badge/chat-on%20slack-e51670.svg)](http://seldondev.slack.com/messages/alibi)

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     license="Apache 2.0",
     packages=find_packages(),
     include_package_data=True,
-    python_requires=">3.5.1",
+    python_requires=">=3.6",
     setup_requires=["pytest-runner"],
     install_requires=[
         "creme",


### PR DESCRIPTION
This should work out of the box.

Couple of things to watch out for:

- Unclear whether Prophet is fully supported on Python 3.8, looks like their conda installation is not working (https://github.com/facebook/prophet/issues/1227). We don't currently provide `detect` on conda so that shouldn't be a concern
- Noticed that Tensorflow 2.3.0 pins both scipy (==1.14.1) and numpy(<1.19.0) to non-latest versions (https://github.com/tensorflow/tensorflow/issues/40884)