### PR TITLE
Bump minimum scipy version to 1.3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         "pandas>=0.23.3, <2.0.0",
         "Pillow>=5.4.1, <9.0.0",
         "opencv-python>=3.2.0, <5.0.0",
-        "scipy>=1.1.0, <2.0.0",
+        "scipy>=1.3.0, <2.0.0",
         'scikit-image>=0.14.2, !=0.17.1, <0.19',  # https://github.com/SeldonIO/alibi/issues/215
         "scikit-learn>=0.20.2, <0.25.0",
         "tensorflow>=2.0.0, <2.5.0",


### PR DESCRIPTION
The `alternative` keywoard for `ks_2samp` was introduced in 1.3.0: https://docs.scipy.org/doc/scipy/reference/release.1.3.0.html
This was pointed out by #184.