### PR TITLE
Fix chisquare bugs

### DIFF
--- a/alibi_detect/cd/tabular.py
+++ b/alibi_detect/cd/tabular.py
@@ -38,9 +38,10 @@ class TabularDrift(BaseUnivariateDrift):
             Data used as reference distribution.
         categories_per_feature
             Dict with as keys the column indices of the categorical features and as optional values
-            the number of possible categories for that feature. If left to None, all features are assumed
+            the number of possible categories `n` for that feature. If left to None, all features are assumed
             to be continuous numerical. The column indices are post a potential preprocessing step.
-            Eg: {0: 5, 1: 9, 2: 7} or {0: None, 1: None, 2: None}.
+            Eg: {0: 5, 1: 9, 2: 7} or {0: None, 1: None, 2: None}. In the latter case, the number of categories is
+            inferred from the data. Categories are assumed to take values in the range `[0, 1, ..., n]`.
         preprocess_X_ref
             Whether to already preprocess and infer categories and frequencies for categorical reference data.
         update_X_ref
@@ -82,22 +83,20 @@ class TabularDrift(BaseUnivariateDrift):
         )
         self.alternative = alternative
         if isinstance(categories_per_feature, dict):
-            if None not in list(categories_per_feature.values()):
-                # convert from Dict[int, int] to Dict[int, List[int]]
-                self.categories_per_feature = {f: list(np.arange(v)) for f, v in categories_per_feature.items()}
-            else:  # infer number of possible categories for each categorical feature from reference data
+            # infer number of possible categories for each categorical feature from reference data
+            if None in list(categories_per_feature.values()):
                 X_flat = self.X_ref.reshape(self.X_ref.shape[0], -1)
-                self.categories_per_feature = {f: list(np.unique(X_flat[:, f]))
-                                               for f in categories_per_feature.keys()}
+                categories_per_feature = {f: X_flat[:, f].max().astype(int) + 1 for f in range(self.n_features)}
 
             if update_X_ref is None and preprocess_X_ref:
                 # already infer categories and frequencies for reference data
-                self.X_ref_count = {f: [(self.X_ref[:, f] == v).sum() for v in vals] for f, vals in
-                                    self.categories_per_feature.items()}
+                self.X_ref_count = self._get_counts(X_ref)
             else:
                 self.X_ref_count = None
         else:  # no categorical features assumed present
-            self.categories_per_feature, self.X_ref_count = {}, None
+            categories_per_feature, self.X_ref_count = {}, None
+
+        self.categories_per_feature = categories_per_feature
 
     def feature_score(self, X_ref: np.ndarray, X: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
         """
@@ -117,18 +116,25 @@ class TabularDrift(BaseUnivariateDrift):
         X = X.reshape(X.shape[0], -1)
         X_ref = X_ref.reshape(X_ref.shape[0], -1)
         if self.categories_per_feature:
-            X_count = {f: [(X[:, f] == v).sum() for v in vals] for f, vals in
-                       self.categories_per_feature.items()}
+            X_count = self._get_counts(X)
+
             if not self.X_ref_count:  # compute categorical frequency counts for each feature
-                X_ref_count = {f: [(X_ref[:, f] == v).sum() for v in vals] for f, vals in
-                               self.categories_per_feature.items()}
+                X_ref_count = self._get_counts(X_ref)
             else:
                 X_ref_count = self.X_ref_count
         p_val = np.zeros(self.n_features, dtype=np.float32)
         dist = np.zeros_like(p_val)
         for f in range(self.n_features):
             if f in list(self.categories_per_feature.keys()):
-                dist[f], p_val[f] = chisquare(X_ref_count[f], f_exp=X_count[f])
+                n_ref, n_obs = X_ref_count[f].sum(), X_count[f].sum()
+                dist[f], p_val[f] = chisquare(X_count[f], f_exp=X_ref_count[f] * n_obs / n_ref)
             else:
                 dist[f], p_val[f] = ks_2samp(X_ref[:, f], X[:, f], alternative=self.alternative, mode='asymp')
         return p_val, dist
+
+    def _get_counts(self, X: np.ndarray) -> Dict[int, np.ndarray]:
+        """
+        Utility method for getting the counts of categories for each categorical variable.
+        """
+        return {f: np.bincount(X[:, f].astype(int), minlength=n_cat) for f, n_cat in
+                self.categories_per_feature.items()}

--- a/alibi_detect/cd/tabular.py
+++ b/alibi_detect/cd/tabular.py
@@ -86,7 +86,7 @@ class TabularDrift(BaseUnivariateDrift):
             # infer number of possible categories for each categorical feature from reference data
             if None in list(categories_per_feature.values()):
                 X_flat = self.X_ref.reshape(self.X_ref.shape[0], -1)
-                categories_per_feature = {f: X_flat[:, f].max().astype(int) + 1 for f in range(self.n_features)}
+                self.categories_per_feature = {f: X_flat[:, f].max().astype(int) + 1 for f in range(self.n_features)}
 
             if update_X_ref is None and preprocess_X_ref:
                 # already infer categories and frequencies for reference data
@@ -94,9 +94,7 @@ class TabularDrift(BaseUnivariateDrift):
             else:
                 self.X_ref_count = None
         else:  # no categorical features assumed present
-            categories_per_feature, self.X_ref_count = {}, None
-
-        self.categories_per_feature = categories_per_feature
+            self.categories_per_feature, self.X_ref_count = {}, None
 
     def feature_score(self, X_ref: np.ndarray, X: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
         """


### PR DESCRIPTION
- Fix the order of test vs reference data for the `chisquare` function
- Account for the difference in sample sizes when computing the test statistic
- Simplify the handling of the number of categories - always assume categories take values in `[0,...,n]`

We could factor out the `_get_counts` method but not sure where to put it, might be more readable just to keep it with each implementation as it's a one-liner.