### PR TITLE
Pin pystan to working release with prophet

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def readme():
 exec(open("alibi_detect/version.py").read())
 
 extras_require = {"examples": ["seaborn>=0.9.0", "tqdm>=4.28.1", "nlp>=0.3.0"],
-                  "prophet": ["fbprophet>=0.5, <0.7", "holidays==0.9.11"]}
+                  "prophet": ["fbprophet>=0.5, <0.7", "holidays==0.9.11", "pystan<3.0"]}
 
 setup(
     name="alibi-detect",


### PR DESCRIPTION
`pystan` 3.0 dropped but it's incompatible with `fbprophet`, pinning it here explicitly. See https://github.com/facebook/prophet/issues/1856.