### PR TITLE
Switch from GOF test to homogeneity test when using chi-squared test statistic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ __pycache__/
 # pycharm
 .idea/
 
+# vscode
+.vscode
+
 # C extensions
 *.so
 

--- a/alibi_detect/cd/chisquare.py
+++ b/alibi_detect/cd/chisquare.py
@@ -1,6 +1,6 @@
 import logging
 import numpy as np
-from scipy.stats import chisquare
+from scipy.stats import chi2_contingency
 from typing import Callable, Dict, Optional, Tuple, Union
 from alibi_detect.cd.base import BaseUnivariateDrift
 
@@ -112,8 +112,8 @@ class ChiSquareDrift(BaseUnivariateDrift):
         p_val = np.zeros(self.n_features, dtype=np.float32)
         dist = np.zeros_like(p_val)
         for f in range(self.n_features):  # apply Chi-Squared test
-            n_ref, n_obs = X_ref_count[f].sum(), X_count[f].sum()
-            dist[f], p_val[f] = chisquare(X_count[f], f_exp=X_ref_count[f] * n_obs / n_ref)
+            contingency_table = np.vstack((X_ref_count[f], X_count[f]))
+            dist[f], p_val[f], _, _ = chi2_contingency(contingency_table)
         return p_val, dist
 
     def _get_counts(self, X: np.ndarray) -> Dict[int, np.ndarray]:

--- a/alibi_detect/cd/tabular.py
+++ b/alibi_detect/cd/tabular.py
@@ -86,7 +86,7 @@ class TabularDrift(BaseUnivariateDrift):
             # infer number of possible categories for each categorical feature from reference data
             if None in list(categories_per_feature.values()):
                 X_flat = self.X_ref.reshape(self.X_ref.shape[0], -1)
-                categories_per_feature = {f: X_flat[:, f].max().astype(int) + 1 for f in range(self.n_features)}
+                categories_per_feature = {f: X_flat[:, f].max().astype(int) + 1 for f in categories_per_feature.keys()}
             self.categories_per_feature = categories_per_feature
 
             if update_X_ref is None and preprocess_X_ref:

--- a/alibi_detect/cd/tabular.py
+++ b/alibi_detect/cd/tabular.py
@@ -1,6 +1,6 @@
 import logging
 import numpy as np
-from scipy.stats import chisquare, ks_2samp
+from scipy.stats import chi2_contingency, ks_2samp
 from typing import Callable, Dict, Optional, Tuple
 from alibi_detect.cd.base import BaseUnivariateDrift
 
@@ -125,8 +125,8 @@ class TabularDrift(BaseUnivariateDrift):
         dist = np.zeros_like(p_val)
         for f in range(self.n_features):
             if f in list(self.categories_per_feature.keys()):
-                n_ref, n_obs = X_ref_count[f].sum(), X_count[f].sum()
-                dist[f], p_val[f] = chisquare(X_count[f], f_exp=X_ref_count[f] * n_obs / n_ref)
+                contingency_table = np.vstack((X_ref_count[f], X_count[f]))
+                dist[f], p_val[f], _, _ = chi2_contingency(contingency_table)
             else:
                 dist[f], p_val[f] = ks_2samp(X_ref[:, f], X[:, f], alternative=self.alternative, mode='asymp')
         return p_val, dist


### PR DESCRIPTION
Currently for each categorical feature the chi-squared drift detector performs a goodness of fit test of the observed data against the empirical distribution of the reference data. This biases p-values towards extremes because it doesn't allow for the possibility that an underlying distribution somewhere between the empirical distributions of the observed and reference data generated both. Instead a test for homogeneity should be performed. This can be thought of as instead identifying the distribution most likely to have generated both and performing a goodness-of-fit test on that. 

The difference should only be slight for large reference sets.
