### PR TITLE
Remove tests where update_x_ref is not None for lsdd detector

### DIFF
--- a/alibi_detect/cd/pytorch/tests/test_lsdd_pt.py
+++ b/alibi_detect/cd/pytorch/tests/test_lsdd_pt.py
@@ -28,7 +28,7 @@ preprocess = [
     (None, None),
     (preprocess_drift, {'model': HiddenOutput, 'layer': -1})
 ]
-update_x_ref = [{'last': 750}, {'reservoir_sampling': 750}, None]
+update_x_ref = [None]
 preprocess_x_ref = [True, False]
 n_permutations = [10]
 tests_lsdddrift = list(product(n_features, n_enc, preprocess,

--- a/alibi_detect/cd/tensorflow/tests/test_lsdd_tf.py
+++ b/alibi_detect/cd/tensorflow/tests/test_lsdd_tf.py
@@ -27,7 +27,7 @@ preprocess = [
     (preprocess_drift, {'model': HiddenOutput, 'layer': -1}),
     (preprocess_drift, {'model': UAE})
 ]
-update_x_ref = [{'last': 750}, {'reservoir_sampling': 750}, None]
+update_x_ref = [None]
 preprocess_x_ref = [True, False]
 n_permutations = [10]
 tests_lsdddrift = list(product(n_features, n_enc, preprocess,


### PR DESCRIPTION
Updating reference data in the lsdd detector is currently buggy, as documented by #261, and occasionally causes tests to fail.