### PR TITLE
Allow for DeepKernel without kernel_b component.

### DIFF
--- a/alibi_detect/utils/pytorch/tests/test_kernels_pt.py
+++ b/alibi_detect/utils/pytorch/tests/test_kernels_pt.py
@@ -50,8 +50,8 @@ class MyKernel(nn.Module):  # TODO: Support then test models using keras functio
 
 n_features = [5, 10]
 n_instances = [(100, 100), (100, 75)]
-kernel_a = [None, MyKernel]
-kernel_b = [None, MyKernel]
+kernel_a = [GaussianRBF(trainable=True), MyKernel]
+kernel_b = [GaussianRBF(trainable=True), MyKernel, None]
 eps = [0.5, 'trainable']
 tests_dk = list(product(n_features, n_instances, kernel_a, kernel_b, eps))
 n_tests_dk = len(tests_dk)
@@ -70,8 +70,8 @@ def test_deep_kernel(deep_kernel_params):
     y = torch.as_tensor(np.random.random(yshape).astype('float32'))
 
     proj = nn.Linear(n_features, n_features)
-    kernel_a = GaussianRBF(trainable=True) if kernel_a is None else kernel_a(n_features)
-    kernel_b = GaussianRBF(trainable=True) if kernel_b is None else kernel_b(n_features)
+    kernel_a = kernel_a(n_features) if kernel_a == MyKernel else kernel_a
+    kernel_b = kernel_b(n_features) if kernel_b == MyKernel else kernel_b
 
     kernel = DeepKernel(proj, kernel_a=kernel_a, kernel_b=kernel_b, eps=eps)
 

--- a/alibi_detect/utils/tensorflow/kernels.py
+++ b/alibi_detect/utils/tensorflow/kernels.py
@@ -87,7 +87,7 @@ class DeepKernel(tf.keras.Model):
         self,
         proj: tf.keras.Model,
         kernel_a: tf.keras.Model = GaussianRBF(trainable=True),
-        kernel_b: tf.keras.Model = GaussianRBF(trainable=True),
+        kernel_b: Optional[tf.keras.Model] = GaussianRBF(trainable=True),
         eps: Union[float, str] = 'trainable'
     ) -> None:
         super().__init__()

--- a/alibi_detect/utils/tensorflow/tests/test_kernels_tf.py
+++ b/alibi_detect/utils/tensorflow/tests/test_kernels_tf.py
@@ -49,8 +49,8 @@ class MyKernel(tf.keras.Model):  # TODO: Support then test models using keras fu
 
 n_features = [5, 10]
 n_instances = [(100, 100), (100, 75)]
-kernel_a = [None, MyKernel]
-kernel_b = [None, MyKernel]
+kernel_a = [GaussianRBF(trainable=True), MyKernel]
+kernel_b = [GaussianRBF(trainable=True), MyKernel, None]
 eps = [0.5, 'trainable']
 tests_dk = list(product(n_features, n_instances, kernel_a, kernel_b, eps))
 n_tests_dk = len(tests_dk)
@@ -69,8 +69,8 @@ def test_deep_kernel(deep_kernel_params):
     y = tf.convert_to_tensor(np.random.random(yshape).astype('float32'))
 
     proj = tf.keras.Sequential([Input(shape=(n_features,)), Dense(n_features)])
-    kernel_a = GaussianRBF(trainable=True) if kernel_a is None else kernel_a(n_features)
-    kernel_b = GaussianRBF(trainable=True) if kernel_b is None else kernel_b(n_features)
+    kernel_a = kernel_a(n_features) if kernel_a == MyKernel else kernel_a
+    kernel_b = kernel_b(n_features) if kernel_b == MyKernel else kernel_b
 
     kernel = DeepKernel(proj, kernel_a=kernel_a, kernel_b=kernel_b, eps=eps)
 


### PR DESCRIPTION
Is now possible to set `kernel_b=None`. 

This seemed preferable to allowing both a kernel_b to be specified and `eps=0`.