### PR TITLE
Do not extend pickle dispatch table on importing dill

### DIFF
--- a/alibi_detect/datasets.py
+++ b/alibi_detect/datasets.py
@@ -14,6 +14,9 @@ from urllib.request import urlopen
 from xml.etree import ElementTree
 from alibi_detect.utils.data import Bunch
 
+# do not extend pickle dispatch table so as not to change pickle behaviour
+dill.extend(use_dill=False)
+
 pd.options.mode.chained_assignment = None  # default='warn'
 
 logger = logging.getLogger(__name__)

--- a/alibi_detect/utils/fetching.py
+++ b/alibi_detect/utils/fetching.py
@@ -13,6 +13,9 @@ from alibi_detect.od import (IForest, LLR, Mahalanobis, OutlierAE, OutlierAEGMM,
                              OutlierSeq2Seq, OutlierVAE, OutlierVAEGMM, SpectralResidual)
 from alibi_detect.utils.saving import load_detector  # type: ignore
 
+# do not extend pickle dispatch table so as not to change pickle behaviour
+dill.extend(use_dill=False)
+
 logger = logging.getLogger(__name__)
 
 Data = Union[

--- a/alibi_detect/utils/saving.py
+++ b/alibi_detect/utils/saving.py
@@ -25,6 +25,9 @@ from alibi_detect.od import (IForest, LLR, Mahalanobis, OutlierAE, OutlierAEGMM,
 from alibi_detect.od.llr import build_model
 from alibi_detect.utils.tensorflow.kernels import GaussianRBF
 
+# do not extend pickle dispatch table so as not to change pickle behaviour
+dill.extend(use_dill=False)
+
 logger = logging.getLogger(__name__)
 
 Data = Union[


### PR DESCRIPTION
Resolves #326.

Even though it is enough to add this in one place due to python modules only being imported once, I decided to add it in all modules that import `dill` so that it's more clear and we avoid accidental regressions if we remove `dill` from a module in the future.