### PR TITLE
Replicate reathedocs environment on Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,15 +58,21 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: Create a virtualenv to use for docs build
+        run: |
+          python3.8 -m virtualenv $HOME/docs
       - name: Install dependencies
         run: |
-          pip3 install -r requirements/docs.txt
-          pip3 freeze
+          . $HOME/docs/bin/activate
+          python -m pip install -r requirements/docs.txt
+          python -m pip freeze
       - name: Build documentation to html
         run: |
+          . $HOME/docs/bin/activate
           make build_docs
       - name: Build documentation to pdf via latex
         run: |
+          . $HOME/docs/bin/activate
           make build_latex
 
   licenses:

--- a/Makefile
+++ b/Makefile
@@ -15,12 +15,17 @@ mypy: ## Run typeckecking according to mypy configuration in setup.cfg
 	mypy .
 
 .PHONY: build_docs
-build_docs: ## Build the documentation
-	$(MAKE) -C doc html
+build_docs:
+	# readthedocs.org build command
+	python -m sphinx -T -b html -d _build/doctrees -D language=en doc/source  doc/_build/html
 
 .PHONY: build_latex
 build_latex: ## Build the documentation into a pdf
-	$(MAKE) -C doc latexpdf
+	# readthedocs.org build command
+	# explicit cd here due to a bug in latexmk 4.41
+	python -m sphinx -b latex -d _build/doctrees -D language=en doc/source doc/_build/latex && \
+	cd doc/_build/latex && \
+	latexmk -pdf -f -dvi- -ps- -jobname=alibi-detect -interaction=nonstopmode
 
 .PHONY: clean_docs
 clean_docs: ## Clean the documentation build
@@ -54,5 +59,5 @@ licenses:
 	# check if there has been a change in license information, used in CI
 check_licenses:
 	git --no-pager diff --exit-code ./licenses/license_info.no_versions.csv
-	
-	
+
+


### PR DESCRIPTION
Update the CI script to use `virtualenv` and update sphinx commands, the same as in https://github.com/SeldonIO/alibi/pull/475.