### PR TITLE
Check for older artifacts without version key in metadata

### DIFF
--- a/alibi_detect/utils/saving.py
+++ b/alibi_detect/utils/saving.py
@@ -985,8 +985,8 @@ def load_detector(filepath: Union[str, os.PathLike], **kwargs) -> Data:
     # check version
     try:
         if meta_dict['version'] != __version__:
-            warnings.warn(f'Trying to load detector from version {meta_dict["version"]} when using version {__version__}. '
-                          f'This may lead to breaking code or invalid results.')
+            warnings.warn(f'Trying to load detector from version {meta_dict["version"]} when using version '
+                          f'{__version__}. This may lead to breaking code or invalid results.')
     except KeyError:
         warnings.warn('Trying to load detector from an older version.'
                       'This may lead to breaking code or invalid results.')

--- a/alibi_detect/utils/saving.py
+++ b/alibi_detect/utils/saving.py
@@ -983,9 +983,13 @@ def load_detector(filepath: Union[str, os.PathLike], **kwargs) -> Data:
     meta_dict = dill.load(open(filepath.joinpath('meta' + suffix), 'rb'))
 
     # check version
-    if meta_dict['version'] != __version__:
-        warnings.warn(f'Trying to load detector from version {meta_dict["version"]} when using version {__version__}. '
-                      f'This may lead to breaking code or invalid results.')
+    try:
+        if meta_dict['version'] != __version__:
+            warnings.warn(f'Trying to load detector from version {meta_dict["version"]} when using version {__version__}. '
+                          f'This may lead to breaking code or invalid results.')
+    except KeyError:
+        warnings.warn('Trying to load detector from an older version.'
+                      'This may lead to breaking code or invalid results.')
 
     if 'backend' in list(meta_dict.keys()) and meta_dict['backend'] == 'pytorch':
         raise NotImplementedError('Detectors with PyTorch backend are not yet supported.')


### PR DESCRIPTION
This fixes the issue of not being able to load older artefacts that don't have a `version` key. Tested on a notebook fetching a pre-trained detector.