### PR TITLE
Update save utils to use `pathlib` instead of `os` for all path operations

### DIFF
--- a/alibi_detect/models/tensorflow/resnet.py
+++ b/alibi_detect/models/tensorflow/resnet.py
@@ -3,6 +3,7 @@
 import argparse
 import numpy as np
 import os
+from pathlib import Path
 import tensorflow as tf
 from tensorflow.keras.callbacks import Callback, ModelCheckpoint
 from tensorflow.keras.initializers import RandomNormal
@@ -438,7 +439,7 @@ def scale_by_instance(x: np.ndarray, eps: float = 1e-12) -> np.ndarray:
 def run(num_blocks: int,
         epochs: int,
         batch_size: int,
-        model_dir: str,
+        model_dir: Union[str, os.PathLike],
         num_classes: int = 10,
         input_shape: Tuple[int, int, int] = (32, 32, 3),
         validation_freq: int = 10,
@@ -465,7 +466,7 @@ def run(num_blocks: int,
 
     # set up callbacks
     steps_per_epoch = X_train.shape[0] // batch_size
-    ckpt_path = os.path.join(model_dir, 'model.h5')
+    ckpt_path = Path(model_dir).joinpath('model.h5')
     callbacks = [
         ModelCheckpoint(
             ckpt_path,

--- a/alibi_detect/od/llr.py
+++ b/alibi_detect/od/llr.py
@@ -26,6 +26,8 @@ def build_model(dist: Union[Distribution, PixelCNN], input_shape: tuple = None, 
         TensorFlow distribution.
     input_shape
         Input shape of the model.
+    filepath
+        File to load model weights from.
 
     Returns
     -------

--- a/alibi_detect/utils/fetching.py
+++ b/alibi_detect/utils/fetching.py
@@ -56,7 +56,6 @@ def get_pixelcnn_default_kwargs():
 
 
 def fetch_tf_model(dataset: str, model: str) -> tf.keras.Model:
-    # TODO - check this
     """
     Fetch pretrained tensorflow models from the google cloud bucket.
 
@@ -327,8 +326,8 @@ def fetch_seq2seq(url: str, filepath: Union[str, os.PathLike]) -> None:
     """
     url_models = os.path.join(url, 'model')
     model_path = Path(filepath).joinpath('model').resolve()
-    if not os.path.isdir(model_path):
-        os.mkdir(model_path)
+    if not model_path.is_dir():
+        model_path.mkdir(parents=True, exist_ok=True)
     # save seq2seq
     tf.keras.utils.get_file(
         model_path.joinpath('checkpoint'),

--- a/alibi_detect/utils/saving.py
+++ b/alibi_detect/utils/saving.py
@@ -1106,7 +1106,7 @@ def load_tf_hl(filepath: Union[str, os.PathLike], model: tf.keras.Model, state_d
     model_dir = Path(filepath).joinpath('model')
     hidden_layer_kld = state_dict['hidden_layer_kld']
     if not hidden_layer_kld:
-        return [None]
+        return []
     model_hl = []
     for i, (hidden_layer, output_dim) in enumerate(hidden_layer_kld.items()):
         m = DenseHidden(model, hidden_layer, output_dim)


### PR DESCRIPTION
Fixes #335. 

`os.path.join` and other `os.path` operations are replaced with their `pathlib` equivalents. `os.path.join` is still used when operating on url's, as `pathlib` complicates matters here.