### PR TITLE
Refactor online detectors

### DIFF
--- a/alibi_detect/cd/base_online.py
+++ b/alibi_detect/cd/base_online.py
@@ -90,10 +90,10 @@ class BaseDriftOnline(BaseDetector):
         pass
 
     @abstractmethod
-    def _update_state(self, x_t: Union[np.ndarray, list]):
+    def _update_state(self, x_t: Union[np.ndarray, Any]):
         pass
 
-    def _preprocess_xt(self, x_t: Union[np.ndarray, list]) -> np.ndarray:
+    def _preprocess_xt(self, x_t: Union[np.ndarray, Any]) -> np.ndarray:
         """
         Private method to preprocess a single test instance ready for _update_state.
 

--- a/alibi_detect/cd/base_online.py
+++ b/alibi_detect/cd/base_online.py
@@ -1,7 +1,7 @@
 from abc import abstractmethod
 import logging
 import numpy as np
-from typing import Callable, Dict,  Optional, Union
+from typing import Any, Callable, Dict,  Optional, Union
 from alibi_detect.base import BaseDetector, concept_drift_dict
 from alibi_detect.cd.utils import get_input_shape
 from alibi_detect.utils.frameworks import has_pytorch, has_tensorflow
@@ -125,7 +125,7 @@ class BaseDriftOnline(BaseDetector):
         "Resets the detector but does not reconfigure thresholds."
         self._initialise()
 
-    def predict(self, x_t: Union[np.ndarray, list],  return_test_stat: bool = True,
+    def predict(self, x_t: Union[np.ndarray, Any],  return_test_stat: bool = True,
                 ) -> Dict[Dict[str, str], Dict[str, Union[int, float]]]:
         """
         Predict whether the most recent window of data has drifted from the reference data.

--- a/alibi_detect/cd/base_online.py
+++ b/alibi_detect/cd/base_online.py
@@ -90,7 +90,7 @@ class BaseDriftOnline(BaseDetector):
         pass
 
     @abstractmethod
-    def _update_state(self, x_t: Union[np.ndarray, Any]):
+    def _update_state(self, x_t: Union[np.ndarray, 'tf.Tensor', 'torch.Tensor']):
         pass
 
     def _preprocess_xt(self, x_t: Union[np.ndarray, Any]) -> np.ndarray:

--- a/alibi_detect/cd/base_online.py
+++ b/alibi_detect/cd/base_online.py
@@ -68,12 +68,6 @@ class BaseDriftOnline(BaseDetector):
         else:
             self.x_ref = x_ref
 
-        # Convert reference data if necessary
-        if isinstance(self.x_ref, list):
-            self.x_ref = np.array(self.x_ref)
-        if self.x_ref.ndim == 1:
-            self.x_ref = self.x_ref[:, None]
-
         # Other attributes
         self.preprocess_fn = preprocess_fn
         self.n = len(x_ref)  # type: ignore
@@ -120,9 +114,7 @@ class BaseDriftOnline(BaseDetector):
         if isinstance(self.preprocess_fn, Callable):  # type: ignore
             x_t = x_t[None, :] if isinstance(x_t, np.ndarray) else [x_t]
             x_t = self.preprocess_fn(x_t)[0]  # type: ignore
-        if isinstance(x_t, list):
-            x_t = np.array(x_t)
-        return x_t[None, :]
+        return x_t[None, :]  # type: ignore
 
     def get_threshold(self, t: int) -> Union[float, None]:
         return self.thresholds[t] if t < self.window_size else self.thresholds[-1]  # type: ignore

--- a/alibi_detect/cd/base_online.py
+++ b/alibi_detect/cd/base_online.py
@@ -110,7 +110,7 @@ class BaseDriftOnline(BaseDetector):
         if isinstance(self.preprocess_fn, Callable):  # type: ignore
             x_t = x_t[None, :] if isinstance(x_t, np.ndarray) else [x_t]
             x_t = self.preprocess_fn(x_t)[0]  # type: ignore
-        return x_t[None, :]  # type: ignore
+        return x_t[None, :]
 
     def get_threshold(self, t: int) -> Union[float, None]:
         return self.thresholds[t] if t < self.window_size else self.thresholds[-1]  # type: ignore

--- a/alibi_detect/cd/base_online.py
+++ b/alibi_detect/cd/base_online.py
@@ -77,10 +77,6 @@ class BaseDriftOnline(BaseDetector):
         # store input shape for save and load functionality
         self.input_shape = get_input_shape(input_shape, x_ref)
 
-        # Init results attributes
-        self.test_stats = None
-        self.drift_preds = None
-
         # set metadata
         self.meta['detector_type'] = 'online'
         self.meta['data_type'] = data_type

--- a/alibi_detect/cd/lsdd.py
+++ b/alibi_detect/cd/lsdd.py
@@ -1,5 +1,5 @@
 import numpy as np
-from typing import Callable, Dict, Optional, Union
+from typing import Callable, Dict, Optional, Union, Tuple
 from alibi_detect.utils.frameworks import has_pytorch, has_tensorflow
 
 if has_pytorch:
@@ -108,3 +108,20 @@ class LSDDDrift:
         'data' contains the drift prediction and optionally the p-value, threshold and LSDD metric.
         """
         return self._detector.predict(x, return_p_val, return_distance)
+
+    def score(self, x: Union[np.ndarray, list]) -> Tuple[float, float, np.ndarray]:
+        """
+        Compute the p-value resulting from a permutation test using the least-squares density
+        difference as a distance measure between the reference data and the data to be tested.
+
+        Parameters
+        ----------
+        x
+            Batch of instances.
+
+        Returns
+        -------
+        p-value obtained from the permutation test, the LSDD between the reference and test set
+        and the LSDD values from the permutation test.
+        """
+        return self._detector.score(x)

--- a/alibi_detect/cd/lsdd_online.py
+++ b/alibi_detect/cd/lsdd_online.py
@@ -126,3 +126,18 @@ class LSDDDriftOnline:
         'data' contains the drift prediction and optionally the test-statistic and threshold.
         """
         return self._detector.predict(x_t, return_test_stat)
+
+    def score(self, x_t: Union[np.ndarray, list]) -> float:
+        """
+        Compute the test-statistic (LSDD) between the reference window and test window.
+
+        Parameters
+        ----------
+        x_t
+            A single instance to be added to the test-window.
+
+        Returns
+        -------
+        LSDD estimate between reference window and test window.
+        """
+        return self._detector.score(x_t)

--- a/alibi_detect/cd/lsdd_online.py
+++ b/alibi_detect/cd/lsdd_online.py
@@ -1,5 +1,5 @@
 import numpy as np
-from typing import Callable, Dict, Optional, Union
+from typing import Any, Callable, Dict, Optional, Union
 from alibi_detect.utils.frameworks import has_pytorch, has_tensorflow
 
 if has_pytorch:
@@ -107,7 +107,7 @@ class LSDDDriftOnline:
         "Resets the detector but does not reconfigure thresholds."
         self._detector.reset()
 
-    def predict(self, x_t: Union[np.ndarray, list], return_test_stat: bool = True) \
+    def predict(self, x_t: Union[np.ndarray, Any], return_test_stat: bool = True) \
             -> Dict[Dict[str, str], Dict[str, Union[int, float]]]:
         """
         Predict whether the most recent window of data has drifted from the reference data.
@@ -127,7 +127,7 @@ class LSDDDriftOnline:
         """
         return self._detector.predict(x_t, return_test_stat)
 
-    def score(self, x_t: Union[np.ndarray, list]) -> float:
+    def score(self, x_t: Union[np.ndarray, Any]) -> float:
         """
         Compute the test-statistic (LSDD) between the reference window and test window.
 

--- a/alibi_detect/cd/mmd.py
+++ b/alibi_detect/cd/mmd.py
@@ -1,6 +1,6 @@
 import logging
 import numpy as np
-from typing import Callable, Dict, Optional, Union
+from typing import Callable, Dict, Optional, Union, Tuple
 from alibi_detect.utils.frameworks import has_pytorch, has_tensorflow
 
 if has_pytorch:
@@ -114,3 +114,20 @@ class MMDDrift:
         'data' contains the drift prediction and optionally the p-value, threshold and MMD metric.
         """
         return self._detector.predict(x, return_p_val, return_distance)
+
+    def score(self, x: Union[np.ndarray, list]) -> Tuple[float, float, np.ndarray]:
+        """
+        Compute the p-value resulting from a permutation test using the maximum mean discrepancy
+        as a distance measure between the reference data and the data to be tested.
+
+        Parameters
+        ----------
+        x
+            Batch of instances.
+
+        Returns
+        -------
+        p-value obtained from the permutation test, the MMD^2 between the reference and test set
+        and the MMD^2 values from the permutation test.
+        """
+        return self._detector.score(x)

--- a/alibi_detect/cd/mmd_online.py
+++ b/alibi_detect/cd/mmd_online.py
@@ -1,5 +1,5 @@
 import numpy as np
-from typing import Callable, Dict, Optional, Union
+from typing import Any, Callable, Dict, Optional, Union
 from alibi_detect.utils.frameworks import has_pytorch, has_tensorflow
 
 if has_pytorch:
@@ -106,7 +106,7 @@ class MMDDriftOnline:
         "Resets the detector but does not reconfigure thresholds."
         self._detector.reset()
 
-    def predict(self, x_t: Union[np.ndarray, list], return_test_stat: bool = True) \
+    def predict(self, x_t: Union[np.ndarray, Any], return_test_stat: bool = True) \
             -> Dict[Dict[str, str], Dict[str, Union[int, float]]]:
         """
         Predict whether the most recent window of data has drifted from the reference data.
@@ -126,7 +126,7 @@ class MMDDriftOnline:
         """
         return self._detector.predict(x_t, return_test_stat)
 
-    def score(self, x_t: Union[np.ndarray, list]) -> float:
+    def score(self, x_t: Union[np.ndarray, Any]) -> float:
         """
         Compute the test-statistic (squared MMD) between the reference window and test window.
 

--- a/alibi_detect/cd/mmd_online.py
+++ b/alibi_detect/cd/mmd_online.py
@@ -125,3 +125,18 @@ class MMDDriftOnline:
         'data' contains the drift prediction and optionally the test-statistic and threshold.
         """
         return self._detector.predict(x_t, return_test_stat)
+
+    def score(self, x_t: Union[np.ndarray, list]) -> float:
+        """
+        Compute the test-statistic (squared MMD) between the reference window and test window.
+
+        Parameters
+        ----------
+        x_t
+            A single instance to be added to the test-window.
+
+        Returns
+        -------
+        Squared MMD estimate between reference window and test window.
+        """
+        return self._detector.score(x_t)

--- a/alibi_detect/cd/pytorch/lsdd_online.py
+++ b/alibi_detect/cd/pytorch/lsdd_online.py
@@ -1,7 +1,7 @@
 from tqdm import tqdm
 import numpy as np
 import torch
-from typing import Callable, Optional, Union
+from typing import Any, Callable, Optional, Union
 from alibi_detect.cd.base_online import BaseDriftOnline
 from alibi_detect.utils.pytorch import GaussianRBF, permed_lsdds, quantile
 
@@ -178,7 +178,7 @@ class LSDDDriftOnlineTorch(BaseDriftOnline):
             h_init = self.c2s - self.k_xtc.mean(0)  # (Eqn 21)
             lsdd_init = h_init[None, :] @ self.H_lam_inv @ h_init[:, None]  # (Eqn 11)
 
-    def _update_state(self, x_t: Union[np.ndarray, list]):
+    def _update_state(self, x_t: Union[np.ndarray, Any]):
         self.t += 1
         x_t = super()._preprocess_xt(x_t)
         x_t = torch.from_numpy(x_t).to(self.device)
@@ -187,7 +187,7 @@ class LSDDDriftOnlineTorch(BaseDriftOnline):
         self.test_window = torch.cat([self.test_window[(1-self.window_size):], x_t], 0)
         self.k_xtc = torch.cat([self.k_xtc[(1-self.window_size):], k_xtc], 0)
 
-    def score(self, x_t: Union[np.ndarray, list]) -> float:
+    def score(self, x_t: Union[np.ndarray, Any]) -> float:
         """
         Compute the test-statistic (LSDD) between the reference window and test window.
 

--- a/alibi_detect/cd/pytorch/lsdd_online.py
+++ b/alibi_detect/cd/pytorch/lsdd_online.py
@@ -178,11 +178,8 @@ class LSDDDriftOnlineTorch(BaseDriftOnline):
             h_init = self.c2s - self.k_xtc.mean(0)  # (Eqn 21)
             lsdd_init = h_init[None, :] @ self.H_lam_inv @ h_init[:, None]  # (Eqn 11)
 
-    def _update_state(self, x_t: Union[np.ndarray, Any]):
+    def _update_state(self, x_t: torch.Tensor):
         self.t += 1
-        x_t = super()._preprocess_xt(x_t)
-        x_t = torch.from_numpy(x_t).to(self.device)
-        x_t = self._normalize(x_t)
         k_xtc = self.kernel(x_t, self.kernel_centers)
         self.test_window = torch.cat([self.test_window[(1-self.window_size):], x_t], 0)
         self.k_xtc = torch.cat([self.k_xtc[(1-self.window_size):], k_xtc], 0)
@@ -200,6 +197,9 @@ class LSDDDriftOnlineTorch(BaseDriftOnline):
         -------
         LSDD estimate between reference window and test window.
         """
+        x_t = super()._preprocess_xt(x_t)
+        x_t = torch.from_numpy(x_t).to(self.device)
+        x_t = self._normalize(x_t)
         self._update_state(x_t)
         h = self.c2s - self.k_xtc.mean(0)  # (Eqn 21)
         lsdd = h[None, :] @ self.H_lam_inv @ h[:, None]  # (Eqn 11)

--- a/alibi_detect/cd/pytorch/lsdd_online.py
+++ b/alibi_detect/cd/pytorch/lsdd_online.py
@@ -179,8 +179,8 @@ class LSDDDriftOnlineTorch(BaseDriftOnline):
             lsdd_init = h_init[None, :] @ self.H_lam_inv @ h_init[:, None]  # (Eqn 11)
 
     def _update_state(self, x_t: Union[np.ndarray, list]):
-        x_t = super()._update_state(x_t)
-
+        self.t += 1
+        x_t = super()._preprocess_xt(x_t)
         x_t = torch.from_numpy(x_t).to(self.device)
         x_t = self._normalize(x_t)
         k_xtc = self.kernel(x_t, self.kernel_centers)

--- a/alibi_detect/cd/pytorch/lsdd_online.py
+++ b/alibi_detect/cd/pytorch/lsdd_online.py
@@ -178,26 +178,36 @@ class LSDDDriftOnlineTorch(BaseDriftOnline):
             h_init = self.c2s - self.k_xtc.mean(0)  # (Eqn 21)
             lsdd_init = h_init[None, :] @ self.H_lam_inv @ h_init[:, None]  # (Eqn 11)
 
-    def score(self, x_t: np.ndarray) -> Union[float, None]:
+    def _update_state(self, x_t: Union[np.ndarray, list]):
+        self.t += 1
+        if isinstance(x_t, list):
+            x_t = np.array(x_t)
+
+        # preprocess if necessary
+        if isinstance(self.preprocess_fn, Callable):  # type: ignore
+            x_t = x_t[None, :] if isinstance(x_t, np.ndarray) else [x_t]
+            x_t = self.preprocess_fn(x_t)[0]  # type: ignore
+
+        x_t = torch.from_numpy(x_t[None, :]).to(self.device)
+        x_t = self._normalize(x_t)
+        k_xtc = self.kernel(x_t, self.kernel_centers)
+        self.test_window = torch.cat([self.test_window[(1-self.window_size):], x_t], 0)
+        self.k_xtc = torch.cat([self.k_xtc[(1-self.window_size):], k_xtc], 0)
+
+    def score(self, x_t: Union[np.ndarray, list]) -> float:
         """
         Compute the test-statistic (LSDD) between the reference window and test window.
-        If the test-window is not yet full then a test-statistic of None is returned.
 
         Parameters
         ----------
         x_t
-            A single instance.
+            A single instance to be added to the test-window.
 
         Returns
         -------
         LSDD estimate between reference window and test window.
         """
-        x_t = torch.from_numpy(x_t[None, :]).to(self.device)
-        x_t = self._normalize(x_t)
-        k_xtc = self.kernel(x_t, self.kernel_centers)
-
-        self.test_window = torch.cat([self.test_window[(1-self.window_size):], x_t], 0)
-        self.k_xtc = torch.cat([self.k_xtc[(1-self.window_size):], k_xtc], 0)
+        self._update_state(x_t)
         h = self.c2s - self.k_xtc.mean(0)  # (Eqn 21)
         lsdd = h[None, :] @ self.H_lam_inv @ h[:, None]  # (Eqn 11)
         return float(lsdd.detach().cpu())

--- a/alibi_detect/cd/pytorch/lsdd_online.py
+++ b/alibi_detect/cd/pytorch/lsdd_online.py
@@ -179,16 +179,9 @@ class LSDDDriftOnlineTorch(BaseDriftOnline):
             lsdd_init = h_init[None, :] @ self.H_lam_inv @ h_init[:, None]  # (Eqn 11)
 
     def _update_state(self, x_t: Union[np.ndarray, list]):
-        self.t += 1
-        if isinstance(x_t, list):
-            x_t = np.array(x_t)
+        x_t = super()._update_state(x_t)
 
-        # preprocess if necessary
-        if isinstance(self.preprocess_fn, Callable):  # type: ignore
-            x_t = x_t[None, :] if isinstance(x_t, np.ndarray) else [x_t]
-            x_t = self.preprocess_fn(x_t)[0]  # type: ignore
-
-        x_t = torch.from_numpy(x_t[None, :]).to(self.device)
+        x_t = torch.from_numpy(x_t).to(self.device)
         x_t = self._normalize(x_t)
         k_xtc = self.kernel(x_t, self.kernel_centers)
         self.test_window = torch.cat([self.test_window[(1-self.window_size):], x_t], 0)

--- a/alibi_detect/cd/pytorch/mmd_online.py
+++ b/alibi_detect/cd/pytorch/mmd_online.py
@@ -167,10 +167,8 @@ class MMDDriftOnlineTorch(BaseDriftOnline):
 
         self.thresholds = thresholds
 
-    def _update_state(self, x_t: Union[np.ndarray, Any]):
+    def _update_state(self, x_t: torch.Tensor):
         self.t += 1
-        x_t = super()._preprocess_xt(x_t)
-        x_t = torch.from_numpy(x_t).to(self.device)
         kernel_col = self.kernel(self.x_ref[self.ref_inds], x_t)
         self.test_window = torch.cat([self.test_window[(1-self.window_size):], x_t], 0)
         self.k_xy = torch.cat([self.k_xy[:, (1-self.window_size):], kernel_col], 1)
@@ -188,6 +186,8 @@ class MMDDriftOnlineTorch(BaseDriftOnline):
         -------
         Squared MMD estimate between reference window and test window.
         """
+        x_t = super()._preprocess_xt(x_t)
+        x_t = torch.from_numpy(x_t).to(self.device)
         self._update_state(x_t)
         k_yy = self.kernel(self.test_window, self.test_window)
         mmd = (

--- a/alibi_detect/cd/pytorch/mmd_online.py
+++ b/alibi_detect/cd/pytorch/mmd_online.py
@@ -168,8 +168,8 @@ class MMDDriftOnlineTorch(BaseDriftOnline):
         self.thresholds = thresholds
 
     def _update_state(self, x_t: Union[np.ndarray, list]):
-        x_t = super()._update_state(x_t)
-
+        self.t += 1
+        x_t = super()._preprocess_xt(x_t)
         x_t = torch.from_numpy(x_t).to(self.device)
         kernel_col = self.kernel(self.x_ref[self.ref_inds], x_t)
         self.test_window = torch.cat([self.test_window[(1-self.window_size):], x_t], 0)

--- a/alibi_detect/cd/pytorch/mmd_online.py
+++ b/alibi_detect/cd/pytorch/mmd_online.py
@@ -168,16 +168,9 @@ class MMDDriftOnlineTorch(BaseDriftOnline):
         self.thresholds = thresholds
 
     def _update_state(self, x_t: Union[np.ndarray, list]):
-        self.t += 1
-        if isinstance(x_t, list):
-            x_t = np.array(x_t)
+        x_t = super()._update_state(x_t)
 
-        # preprocess if necessary
-        if isinstance(self.preprocess_fn, Callable):  # type: ignore
-            x_t = x_t[None, :] if isinstance(x_t, np.ndarray) else [x_t]
-            x_t = self.preprocess_fn(x_t)[0]  # type: ignore
-
-        x_t = torch.from_numpy(x_t[None, :]).to(self.device)
+        x_t = torch.from_numpy(x_t).to(self.device)
         kernel_col = self.kernel(self.x_ref[self.ref_inds], x_t)
         self.test_window = torch.cat([self.test_window[(1-self.window_size):], x_t], 0)
         self.k_xy = torch.cat([self.k_xy[:, (1-self.window_size):], kernel_col], 1)

--- a/alibi_detect/cd/pytorch/mmd_online.py
+++ b/alibi_detect/cd/pytorch/mmd_online.py
@@ -167,30 +167,39 @@ class MMDDriftOnlineTorch(BaseDriftOnline):
 
         self.thresholds = thresholds
 
-    def score(self, x_t: np.ndarray) -> Union[float, None]:
+    def _update_state(self, x_t: Union[np.ndarray, list]):
+        self.t += 1
+        if isinstance(x_t, list):
+            x_t = np.array(x_t)
+
+        # preprocess if necessary
+        if isinstance(self.preprocess_fn, Callable):  # type: ignore
+            x_t = x_t[None, :] if isinstance(x_t, np.ndarray) else [x_t]
+            x_t = self.preprocess_fn(x_t)[0]  # type: ignore
+
+        x_t = torch.from_numpy(x_t[None, :]).to(self.device)
+        kernel_col = self.kernel(self.x_ref[self.ref_inds], x_t)
+        self.test_window = torch.cat([self.test_window[(1-self.window_size):], x_t], 0)
+        self.k_xy = torch.cat([self.k_xy[:, (1-self.window_size):], kernel_col], 1)
+
+    def score(self, x_t: Union[np.ndarray, list]) -> float:
         """
         Compute the test-statistic (squared MMD) between the reference window and test window.
-        If the test-window is not yet full then a test-statistic of None is returned.
 
         Parameters
         ----------
         x_t
-            A single instance.
+            A single instance to be added to the test-window.
 
         Returns
         -------
-        Squared MMD estimate between reference window and test window
+        Squared MMD estimate between reference window and test window.
         """
-        x_t = torch.from_numpy(x_t[None, :]).to(self.device)
-        kernel_col = self.kernel(self.x_ref[self.ref_inds], x_t)
-
-        self.test_window = torch.cat([self.test_window[(1-self.window_size):], x_t], 0)
-        self.k_xy = torch.cat([self.k_xy[:, (1-self.window_size):], kernel_col], 1)
+        self._update_state(x_t)
         k_yy = self.kernel(self.test_window, self.test_window)
         mmd = (
             self.k_xx_sub_sum +
             zero_diag(k_yy).sum()/(self.window_size*(self.window_size-1)) -
             2*self.k_xy.mean()
         )
-
         return float(mmd.detach().cpu())

--- a/alibi_detect/cd/pytorch/mmd_online.py
+++ b/alibi_detect/cd/pytorch/mmd_online.py
@@ -1,7 +1,7 @@
 from tqdm import tqdm
 import numpy as np
 import torch
-from typing import Callable, Optional, Union
+from typing import Any, Callable, Optional, Union
 from alibi_detect.cd.base_online import BaseDriftOnline
 from alibi_detect.utils.pytorch.kernels import GaussianRBF
 from alibi_detect.utils.pytorch import zero_diag, quantile
@@ -167,7 +167,7 @@ class MMDDriftOnlineTorch(BaseDriftOnline):
 
         self.thresholds = thresholds
 
-    def _update_state(self, x_t: Union[np.ndarray, list]):
+    def _update_state(self, x_t: Union[np.ndarray, Any]):
         self.t += 1
         x_t = super()._preprocess_xt(x_t)
         x_t = torch.from_numpy(x_t).to(self.device)
@@ -175,7 +175,7 @@ class MMDDriftOnlineTorch(BaseDriftOnline):
         self.test_window = torch.cat([self.test_window[(1-self.window_size):], x_t], 0)
         self.k_xy = torch.cat([self.k_xy[:, (1-self.window_size):], kernel_col], 1)
 
-    def score(self, x_t: Union[np.ndarray, list]) -> float:
+    def score(self, x_t: Union[np.ndarray, Any]) -> float:
         """
         Compute the test-statistic (squared MMD) between the reference window and test window.
 

--- a/alibi_detect/cd/tensorflow/lsdd_online.py
+++ b/alibi_detect/cd/tensorflow/lsdd_online.py
@@ -165,8 +165,8 @@ class LSDDDriftOnlineTF(BaseDriftOnline):
             lsdd_init = h_init[None, :] @ self.H_lam_inv @ h_init[:, None]  # (Eqn 11)
 
     def _update_state(self, x_t: Union[np.ndarray, list]):
-        x_t = super()._update_state(x_t)
-
+        self.t += 1
+        x_t = super()._preprocess_xt(x_t)
         x_t = tf.convert_to_tensor(x_t)
         x_t = self._normalize(x_t)
         k_xtc = self.kernel(x_t, self.kernel_centers)

--- a/alibi_detect/cd/tensorflow/lsdd_online.py
+++ b/alibi_detect/cd/tensorflow/lsdd_online.py
@@ -164,11 +164,8 @@ class LSDDDriftOnlineTF(BaseDriftOnline):
             h_init = self.c2s - tf.reduce_mean(self.k_xtc, axis=0)  # (Eqn 21)
             lsdd_init = h_init[None, :] @ self.H_lam_inv @ h_init[:, None]  # (Eqn 11)
 
-    def _update_state(self, x_t: Union[np.ndarray, Any]):
+    def _update_state(self, x_t: tf.Tensor):
         self.t += 1
-        x_t = super()._preprocess_xt(x_t)
-        x_t = tf.convert_to_tensor(x_t)
-        x_t = self._normalize(x_t)
         k_xtc = self.kernel(x_t, self.kernel_centers)
         self.test_window = tf.concat([self.test_window[(1-self.window_size):], x_t], axis=0)
         self.k_xtc = tf.concat([self.k_xtc[(1-self.window_size):], k_xtc], axis=0)
@@ -186,6 +183,9 @@ class LSDDDriftOnlineTF(BaseDriftOnline):
         -------
         LSDD estimate between reference window and test window.
         """
+        x_t = super()._preprocess_xt(x_t)
+        x_t = tf.convert_to_tensor(x_t)
+        x_t = self._normalize(x_t)
         self._update_state(x_t)
         h = self.c2s - tf.reduce_mean(self.k_xtc, axis=0)  # (Eqn 21)
         lsdd = h[None, :] @ self.H_lam_inv @ h[:, None]  # (Eqn 11)

--- a/alibi_detect/cd/tensorflow/lsdd_online.py
+++ b/alibi_detect/cd/tensorflow/lsdd_online.py
@@ -165,16 +165,9 @@ class LSDDDriftOnlineTF(BaseDriftOnline):
             lsdd_init = h_init[None, :] @ self.H_lam_inv @ h_init[:, None]  # (Eqn 11)
 
     def _update_state(self, x_t: Union[np.ndarray, list]):
-        self.t += 1
-        if isinstance(x_t, list):
-            x_t = np.array(x_t)
+        x_t = super()._update_state(x_t)
 
-        # preprocess if necessary
-        if isinstance(self.preprocess_fn, Callable):  # type: ignore
-            x_t = x_t[None, :] if isinstance(x_t, np.ndarray) else [x_t]
-            x_t = self.preprocess_fn(x_t)[0]  # type: ignore
-
-        x_t = tf.convert_to_tensor(x_t[None, :])
+        x_t = tf.convert_to_tensor(x_t)
         x_t = self._normalize(x_t)
         k_xtc = self.kernel(x_t, self.kernel_centers)
         self.test_window = tf.concat([self.test_window[(1-self.window_size):], x_t], axis=0)

--- a/alibi_detect/cd/tensorflow/lsdd_online.py
+++ b/alibi_detect/cd/tensorflow/lsdd_online.py
@@ -1,7 +1,7 @@
 from tqdm import tqdm
 import numpy as np
 import tensorflow as tf
-from typing import Callable, Optional, Union
+from typing import Any, Callable, Optional, Union
 from alibi_detect.cd.base_online import BaseDriftOnline
 from alibi_detect.utils.tensorflow import GaussianRBF, quantile, permed_lsdds
 
@@ -164,7 +164,7 @@ class LSDDDriftOnlineTF(BaseDriftOnline):
             h_init = self.c2s - tf.reduce_mean(self.k_xtc, axis=0)  # (Eqn 21)
             lsdd_init = h_init[None, :] @ self.H_lam_inv @ h_init[:, None]  # (Eqn 11)
 
-    def _update_state(self, x_t: Union[np.ndarray, list]):
+    def _update_state(self, x_t: Union[np.ndarray, Any]):
         self.t += 1
         x_t = super()._preprocess_xt(x_t)
         x_t = tf.convert_to_tensor(x_t)
@@ -173,7 +173,7 @@ class LSDDDriftOnlineTF(BaseDriftOnline):
         self.test_window = tf.concat([self.test_window[(1-self.window_size):], x_t], axis=0)
         self.k_xtc = tf.concat([self.k_xtc[(1-self.window_size):], k_xtc], axis=0)
 
-    def score(self, x_t: Union[np.ndarray, list]) -> float:
+    def score(self, x_t: Union[np.ndarray, Any]) -> float:
         """
         Compute the test-statistic (LSDD) between the reference window and test window.
 

--- a/alibi_detect/cd/tensorflow/mmd_online.py
+++ b/alibi_detect/cd/tensorflow/mmd_online.py
@@ -158,17 +158,8 @@ class MMDDriftOnlineTF(BaseDriftOnline):
         self.thresholds = thresholds
 
     def _update_state(self, x_t: Union[np.ndarray, list]):
-        self.t += 1
+        x_t = super()._update_state(x_t)
 
-        if isinstance(x_t, list):
-            x_t = np.array(x_t)
-
-        # preprocess if necessary
-        if isinstance(self.preprocess_fn, Callable):  # type: ignore
-            x_t = x_t[None, :] if isinstance(x_t, np.ndarray) else [x_t]
-            x_t = self.preprocess_fn(x_t)[0]  # type: ignore
-
-        x_t = x_t[None, :]
         kernel_col = self.kernel(self.x_ref[self.ref_inds], x_t)
         self.test_window = tf.concat([self.test_window[(1-self.window_size):], x_t], axis=0)
         self.k_xy = tf.concat([self.k_xy[:, (1-self.window_size):], kernel_col], axis=1)

--- a/alibi_detect/cd/tensorflow/mmd_online.py
+++ b/alibi_detect/cd/tensorflow/mmd_online.py
@@ -157,9 +157,8 @@ class MMDDriftOnlineTF(BaseDriftOnline):
 
         self.thresholds = thresholds
 
-    def _update_state(self, x_t: Union[np.ndarray, Any]):
+    def _update_state(self, x_t: np.ndarray):
         self.t += 1
-        x_t = super()._preprocess_xt(x_t)
         kernel_col = self.kernel(self.x_ref[self.ref_inds], x_t)
         self.test_window = tf.concat([self.test_window[(1-self.window_size):], x_t], axis=0)
         self.k_xy = tf.concat([self.k_xy[:, (1-self.window_size):], kernel_col], axis=1)
@@ -177,6 +176,7 @@ class MMDDriftOnlineTF(BaseDriftOnline):
         -------
         Squared MMD estimate between reference window and test window.
         """
+        x_t = super()._preprocess_xt(x_t)
         self._update_state(x_t)
         k_yy = self.kernel(self.test_window, self.test_window)
         mmd = (

--- a/alibi_detect/cd/tensorflow/mmd_online.py
+++ b/alibi_detect/cd/tensorflow/mmd_online.py
@@ -157,25 +157,36 @@ class MMDDriftOnlineTF(BaseDriftOnline):
 
         self.thresholds = thresholds
 
-    def score(self, x_t: np.ndarray) -> Union[float, None]:
+    def _update_state(self, x_t: Union[np.ndarray, list]):
+        self.t += 1
+
+        if isinstance(x_t, list):
+            x_t = np.array(x_t)
+
+        # preprocess if necessary
+        if isinstance(self.preprocess_fn, Callable):  # type: ignore
+            x_t = x_t[None, :] if isinstance(x_t, np.ndarray) else [x_t]
+            x_t = self.preprocess_fn(x_t)[0]  # type: ignore
+
+        x_t = x_t[None, :]
+        kernel_col = self.kernel(self.x_ref[self.ref_inds], x_t)
+        self.test_window = tf.concat([self.test_window[(1-self.window_size):], x_t], axis=0)
+        self.k_xy = tf.concat([self.k_xy[:, (1-self.window_size):], kernel_col], axis=1)
+
+    def score(self, x_t: Union[np.ndarray, list]) -> float:
         """
         Compute the test-statistic (squared MMD) between the reference window and test window.
-        If the test-window is not yet full then a test-statistic of None is returned.
 
         Parameters
         ----------
         x_t
-            A single instance.
+            A single instance to be added to the test-window.
 
         Returns
         -------
         Squared MMD estimate between reference window and test window.
         """
-        x_t = x_t[None, :]
-        kernel_col = self.kernel(self.x_ref[self.ref_inds], x_t)
-
-        self.test_window = tf.concat([self.test_window[(1-self.window_size):], x_t], axis=0)
-        self.k_xy = tf.concat([self.k_xy[:, (1-self.window_size):], kernel_col], axis=1)
+        self._update_state(x_t)
         k_yy = self.kernel(self.test_window, self.test_window)
         mmd = (
             self.k_xx_sub_sum +

--- a/alibi_detect/cd/tensorflow/mmd_online.py
+++ b/alibi_detect/cd/tensorflow/mmd_online.py
@@ -1,7 +1,7 @@
 from tqdm import tqdm
 import numpy as np
 import tensorflow as tf
-from typing import Callable, Optional, Union
+from typing import Any, Callable, Optional, Union
 from alibi_detect.cd.base_online import BaseDriftOnline
 from alibi_detect.utils.tensorflow.kernels import GaussianRBF
 from alibi_detect.utils.tensorflow import zero_diag, quantile, subset_matrix
@@ -157,14 +157,14 @@ class MMDDriftOnlineTF(BaseDriftOnline):
 
         self.thresholds = thresholds
 
-    def _update_state(self, x_t: Union[np.ndarray, list]):
+    def _update_state(self, x_t: Union[np.ndarray, Any]):
         self.t += 1
         x_t = super()._preprocess_xt(x_t)
         kernel_col = self.kernel(self.x_ref[self.ref_inds], x_t)
         self.test_window = tf.concat([self.test_window[(1-self.window_size):], x_t], axis=0)
         self.k_xy = tf.concat([self.k_xy[:, (1-self.window_size):], kernel_col], axis=1)
 
-    def score(self, x_t: Union[np.ndarray, list]) -> float:
+    def score(self, x_t: Union[np.ndarray, Any]) -> float:
         """
         Compute the test-statistic (squared MMD) between the reference window and test window.
 

--- a/alibi_detect/cd/tensorflow/mmd_online.py
+++ b/alibi_detect/cd/tensorflow/mmd_online.py
@@ -158,8 +158,8 @@ class MMDDriftOnlineTF(BaseDriftOnline):
         self.thresholds = thresholds
 
     def _update_state(self, x_t: Union[np.ndarray, list]):
-        x_t = super()._update_state(x_t)
-
+        self.t += 1
+        x_t = super()._preprocess_xt(x_t)
         kernel_col = self.kernel(self.x_ref[self.ref_inds], x_t)
         self.test_window = tf.concat([self.test_window[(1-self.window_size):], x_t], axis=0)
         self.k_xy = tf.concat([self.k_xy[:, (1-self.window_size):], kernel_col], axis=1)

--- a/alibi_detect/cd/tests/test_lsdd_online.py
+++ b/alibi_detect/cd/tests/test_lsdd_online.py
@@ -31,3 +31,15 @@ def test_lsdddriftonline(lsdddriftonline_params):
         assert isinstance(cd._detector, LSDDDriftOnlineTF)
     else:
         assert cd is None
+        return None
+
+    # Test predict
+    x_t = np.random.randn(n_features)
+    t0 = cd.t
+    cd.predict(x_t)
+    assert cd.t - t0 == 1  # This checks state updated (self.t at least)
+
+    # Test score
+    t0 = cd.t
+    cd.score(x_t)
+    assert cd.t - t0 == 1

--- a/alibi_detect/cd/tests/test_mmd_online.py
+++ b/alibi_detect/cd/tests/test_mmd_online.py
@@ -20,6 +20,7 @@ def test_mmddriftonline(mmddriftonline_params):
     backend = mmddriftonline_params
     x_ref = np.random.randn(*(n, n_features))
 
+    # Instantiate and check detector class
     try:
         cd = MMDDriftOnline(x_ref=x_ref, ert=25, window_size=5, backend=backend, n_bootstraps=100)
     except NotImplementedError:
@@ -31,3 +32,15 @@ def test_mmddriftonline(mmddriftonline_params):
         assert isinstance(cd._detector, MMDDriftOnlineTF)
     else:
         assert cd is None
+        return
+
+    # Test predict
+    x_t = np.random.randn(n_features)
+    t0 = cd.t
+    cd.predict(x_t)
+    assert cd.t - t0 == 1  # This checks state updated (self.t at least)
+
+    # Test score
+    t0 = cd.t
+    cd.score(x_t)
+    assert cd.t - t0 == 1


### PR DESCRIPTION
This PR contains minor(ish?)  refactorings to the online drift detectors. A number of these are intended to be a stepping stone to implementing the non-parametric drift detectors in https://github.com/SeldonIO/alibi-detect/pull/359. 

### Summary of changes
1. `score` and `predict` are refactored to ensure state isn't being updated in multiple places. The state is now updated in `_update_state`, which is called by `score`. This means `score` can now be called without `predict` being called.
2. Preprocessing of `x_t` is moved to `_update_state`, meaning preprocessing is now done for `score` and `predict`. 
3. `score` is exposed as a public method of `MMDDriftOnline` and `LSDDDriftOnline`.
4. `x_t` is converted to `np.ndarray` if given as a `list`.
5. Minor rewording of some docstrings.