### PR TITLE
Dev/fix latest numpy types

### DIFF
--- a/alibi_detect/ad/model_distillation.py
+++ b/alibi_detect/ad/model_distillation.py
@@ -1,13 +1,14 @@
 import logging
+from typing import Callable, Dict, Tuple, Union, cast
+
 import numpy as np
 import tensorflow as tf
-from tensorflow.keras.losses import kld, categorical_crossentropy
-from typing import Callable, Dict, Tuple, Union
-from alibi_detect.models.tensorflow.trainer import trainer
-from alibi_detect.models.tensorflow.losses import loss_distillation
-from alibi_detect.utils.tensorflow.prediction import predict_batch
 from alibi_detect.base import (BaseDetector, FitMixin, ThresholdMixin,
                                adversarial_prediction_dict)
+from alibi_detect.models.tensorflow.losses import loss_distillation
+from alibi_detect.models.tensorflow.trainer import trainer
+from alibi_detect.utils.tensorflow.prediction import predict_batch
+from tensorflow.keras.losses import categorical_crossentropy, kld
 
 logger = logging.getLogger(__name__)
 
@@ -167,6 +168,8 @@ class ModelDistillation(BaseDetector, FitMixin, ThresholdMixin):
         # model predictions
         y = predict_batch(X, self.model, batch_size=batch_size)
         y_distilled = predict_batch(X, self.distilled_model, batch_size=batch_size)
+        y = cast(np.ndarray, y)  # help mypy out
+        y_distilled = cast(np.ndarray, y_distilled)  # help mypy out
 
         # scale predictions
         if self.temperature != 1.:

--- a/alibi_detect/cd/base.py
+++ b/alibi_detect/cd/base.py
@@ -1,24 +1,27 @@
-from abc import abstractmethod
 import logging
-import numpy as np
-from sklearn.model_selection import StratifiedKFold
-from scipy.stats import binom_test, ks_2samp
+from abc import abstractmethod
 from typing import Callable, Dict, List, Optional, Tuple, Union
+
+import numpy as np
 from alibi_detect.base import BaseDetector, concept_drift_dict
 from alibi_detect.cd.utils import get_input_shape, update_reference
 from alibi_detect.utils.frameworks import has_pytorch, has_tensorflow
 from alibi_detect.utils.statstest import fdr
+from scipy.stats import binom_test, ks_2samp
+from sklearn.model_selection import StratifiedKFold
 
 if has_pytorch:
-    import torch  # noqa F401
+    import torch
 
 if has_tensorflow:
-    import tensorflow as tf  # noqa F401
+    import tensorflow as tf
 
 logger = logging.getLogger(__name__)
 
 
 class BaseClassifierDrift(BaseDetector):
+    model: Union['tf.keras.Model', 'torch.nn.Module']
+
     def __init__(
             self,
             x_ref: Union[np.ndarray, list],
@@ -88,14 +91,14 @@ class BaseClassifierDrift(BaseDetector):
 
         # optionally already preprocess reference data
         self.p_val = p_val
-        if preprocess_x_ref and isinstance(preprocess_fn, Callable):  # type: ignore
+        if preprocess_x_ref and isinstance(preprocess_fn, Callable):  # type: ignore[arg-type]
             self.x_ref = preprocess_fn(x_ref)
         else:
             self.x_ref = x_ref
         self.preprocess_x_ref = preprocess_x_ref
         self.update_x_ref = update_x_ref
         self.preprocess_fn = preprocess_fn
-        self.n = len(x_ref)  # type: ignore
+        self.n = len(x_ref)
 
         # define whether soft preds and optionally the stratified k-fold split
         self.preds_type = preds_type
@@ -123,7 +126,7 @@ class BaseClassifierDrift(BaseDetector):
         -------
         Preprocessed reference data and new instances.
         """
-        if isinstance(self.preprocess_fn, Callable):  # type: ignore
+        if isinstance(self.preprocess_fn, Callable):  # type: ignore[arg-type]
             x = self.preprocess_fn(x)
             x_ref = self.x_ref if self.preprocess_x_ref else self.preprocess_fn(self.x_ref)
             return x_ref, x
@@ -166,7 +169,7 @@ class BaseClassifierDrift(BaseDetector):
         return x, y, splits
 
     def test_probs(
-        self, y_oof: np.ndarray, probs_oof: np.ndarray, n_ref: int, n_cur: int
+            self, y_oof: np.ndarray, probs_oof: np.ndarray, n_ref: int, n_cur: int
     ) -> Tuple[float, float]:
         """
         Perform a statistical test of the probabilities predicted by the model against
@@ -194,10 +197,10 @@ class BaseClassifierDrift(BaseDetector):
             n_oof = y_oof.shape[0]
             n_correct = (y_oof == probs_oof.round()).sum()
             p_val = binom_test(n_correct, n_oof, baseline_accuracy, alternative='greater')
-            accuracy = n_correct/n_oof
+            accuracy = n_correct / n_oof
             # relative error reduction, in [0,1]
             # e.g. (90% acc -> 99% acc) = 0.9, (50% acc -> 59% acc) = 0.18
-            dist = 1 - (1 - accuracy)/(1-baseline_accuracy)
+            dist = 1 - (1 - accuracy) / (1 - baseline_accuracy)
             dist = max(0, dist)  # below 0 = no evidence for drift
         else:
             probs_ref = probs_oof[y_oof == 0]
@@ -210,7 +213,7 @@ class BaseClassifierDrift(BaseDetector):
     def score(self, x: Union[np.ndarray, list]) -> Tuple[float, float, np.ndarray, np.ndarray]:
         pass
 
-    def predict(self, x: Union[np.ndarray, list],  return_p_val: bool = True,
+    def predict(self, x: Union[np.ndarray, list], return_p_val: bool = True,
                 return_distance: bool = True, return_probs: bool = True, return_model: bool = True) \
             -> Dict[str, Dict[str, Union[str, int, float, Callable]]]:
         """
@@ -246,9 +249,11 @@ class BaseClassifierDrift(BaseDetector):
         # update reference dataset
         if isinstance(self.update_x_ref, dict) and self.preprocess_fn is not None and self.preprocess_x_ref:
             x = self.preprocess_fn(x)
-        self.x_ref = update_reference(self.x_ref, x, self.n, self.update_x_ref)
+        # TODO: TBD: can `x` ever be a `list` after pre-processing? update_references and downstream functions
+        # don't support list inputs and without the type: ignore[arg-type] mypy complains
+        self.x_ref = update_reference(self.x_ref, x, self.n, self.update_x_ref)  # type: ignore[arg-type]
         # used for reservoir sampling
-        self.n += len(x)  # type: ignore
+        self.n += len(x)
 
         # populate drift dict
         cd = concept_drift_dict()
@@ -263,11 +268,13 @@ class BaseClassifierDrift(BaseDetector):
             cd['data']['probs_ref'] = probs_ref
             cd['data']['probs_test'] = probs_test
         if return_model:
-            cd['data']['model'] = self.model  # type: ignore
+            cd['data']['model'] = self.model
         return cd
 
 
 class BaseLearnedKernelDrift(BaseDetector):
+    kernel: Union['tf.keras.Model', 'torch.nn.Module']
+
     def __init__(
             self,
             x_ref: Union[np.ndarray, list],
@@ -315,14 +322,14 @@ class BaseLearnedKernelDrift(BaseDetector):
 
         # optionally already preprocess reference data
         self.p_val = p_val
-        if preprocess_x_ref and isinstance(preprocess_fn, Callable):  # type: ignore
+        if preprocess_x_ref and isinstance(preprocess_fn, Callable):  # type: ignore[arg-type]
             self.x_ref = preprocess_fn(x_ref)
         else:
             self.x_ref = x_ref
         self.preprocess_x_ref = preprocess_x_ref
         self.update_x_ref = update_x_ref
         self.preprocess_fn = preprocess_fn
-        self.n = len(x_ref)  # type: ignore
+        self.n = len(x_ref)
 
         self.n_permutations = n_permutations
         self.train_size = train_size
@@ -343,7 +350,7 @@ class BaseLearnedKernelDrift(BaseDetector):
         -------
         Preprocessed reference data and new instances.
         """
-        if isinstance(self.preprocess_fn, Callable):  # type: ignore
+        if isinstance(self.preprocess_fn, Callable):  # type: ignore[arg-type]
             x = self.preprocess_fn(x)
             x_ref = self.x_ref if self.preprocess_x_ref else self.preprocess_fn(self.x_ref)
             return x_ref, x
@@ -369,8 +376,8 @@ class BaseLearnedKernelDrift(BaseDetector):
 
         n_ref, n_cur = len(x_ref), len(x)
         perm_ref, perm_cur = np.random.permutation(n_ref), np.random.permutation(n_cur)
-        idx_ref_tr, idx_ref_te = perm_ref[:int(n_ref*self.train_size)], perm_ref[int(n_ref*self.train_size):]
-        idx_cur_tr, idx_cur_te = perm_cur[:int(n_cur*self.train_size)], perm_cur[int(n_cur*self.train_size):]
+        idx_ref_tr, idx_ref_te = perm_ref[:int(n_ref * self.train_size)], perm_ref[int(n_ref * self.train_size):]
+        idx_cur_tr, idx_cur_te = perm_cur[:int(n_cur * self.train_size)], perm_cur[int(n_cur * self.train_size):]
 
         if isinstance(x_ref, np.ndarray):
             x_ref_tr, x_ref_te = x_ref[idx_ref_tr], x_ref[idx_ref_te]
@@ -387,7 +394,7 @@ class BaseLearnedKernelDrift(BaseDetector):
     def score(self, x: Union[np.ndarray, list]) -> Tuple[float, float, np.ndarray]:
         pass
 
-    def predict(self, x: Union[np.ndarray, list],  return_p_val: bool = True,
+    def predict(self, x: Union[np.ndarray, list], return_p_val: bool = True,
                 return_distance: bool = True, return_kernel: bool = True) \
             -> Dict[Dict[str, str], Dict[str, Union[int, float, Callable]]]:
         """
@@ -422,9 +429,9 @@ class BaseLearnedKernelDrift(BaseDetector):
         # update reference dataset
         if isinstance(self.update_x_ref, dict) and self.preprocess_fn is not None and self.preprocess_x_ref:
             x = self.preprocess_fn(x)
-        self.x_ref = update_reference(self.x_ref, x, self.n, self.update_x_ref)
+        self.x_ref = update_reference(self.x_ref, x, self.n, self.update_x_ref)  # type: ignore[arg-type]
         # used for reservoir sampling
-        self.n += len(x)  # type: ignore
+        self.n += len(x)
 
         # populate drift dict
         cd = concept_drift_dict()
@@ -437,7 +444,7 @@ class BaseLearnedKernelDrift(BaseDetector):
             cd['data']['distance'] = dist
             cd['data']['distance_threshold'] = distance_threshold
         if return_kernel:
-            cd['data']['kernel'] = self.kernel  # type: ignore
+            cd['data']['kernel'] = self.kernel
         return cd
 
 
@@ -498,14 +505,14 @@ class BaseMMDDrift(BaseDetector):
 
         # optionally already preprocess reference data
         self.p_val = p_val
-        if preprocess_x_ref and isinstance(preprocess_fn, Callable):  # type: ignore
+        if preprocess_x_ref and isinstance(preprocess_fn, Callable):  # type: ignore[arg-type]
             self.x_ref = preprocess_fn(x_ref)
         else:
             self.x_ref = x_ref
         self.preprocess_x_ref = preprocess_x_ref
         self.update_x_ref = update_x_ref
         self.preprocess_fn = preprocess_fn
-        self.n = len(x_ref)  # type: ignore
+        self.n = len(x_ref)
         self.n_permutations = n_permutations  # nb of iterations through permutation test
 
         # store input shape for save and load functionality
@@ -525,12 +532,14 @@ class BaseMMDDrift(BaseDetector):
         -------
         Preprocessed reference data and new instances.
         """
-        if isinstance(self.preprocess_fn, Callable):  # type: ignore
+        if isinstance(self.preprocess_fn, Callable):  # type: ignore[arg-type]
             x = self.preprocess_fn(x)
             x_ref = self.x_ref if self.preprocess_x_ref else self.preprocess_fn(self.x_ref)
-            return x_ref, x
+            # TODO: TBD: similar to above, can x be a list here? x_ref is also revealed to be Any,
+            #  can we tighten the type up (e.g. by typing Callable with stricter inputs/outputs?
+            return x_ref, x  # type: ignore[return-value]
         else:
-            return self.x_ref, x
+            return self.x_ref, x  # type: ignore[return-value]
 
     @abstractmethod
     def kernel_matrix(self, x: Union['torch.Tensor', 'tf.Tensor'], y: Union['torch.Tensor', 'tf.Tensor']) \
@@ -572,9 +581,9 @@ class BaseMMDDrift(BaseDetector):
         # update reference dataset
         if isinstance(self.update_x_ref, dict) and self.preprocess_fn is not None and self.preprocess_x_ref:
             x = self.preprocess_fn(x)
-        self.x_ref = update_reference(self.x_ref, x, self.n, self.update_x_ref)
+        self.x_ref = update_reference(self.x_ref, x, self.n, self.update_x_ref)  # type: ignore[arg-type]
         # used for reservoir sampling
-        self.n += len(x)  # type: ignore
+        self.n += len(x)
 
         # populate drift dict
         cd = concept_drift_dict()
@@ -590,6 +599,10 @@ class BaseMMDDrift(BaseDetector):
 
 
 class BaseLSDDDrift(BaseDetector):
+    # TODO: TBD: this is only created when _configure_normalization is called from backend-specific classes,
+    # is declaring it here the right thing to do?
+    _normalize: Callable
+
     def __init__(
             self,
             x_ref: Union[np.ndarray, list],
@@ -646,7 +659,7 @@ class BaseLSDDDrift(BaseDetector):
 
         # optionally already preprocess reference data
         self.p_val = p_val
-        if preprocess_x_ref and isinstance(preprocess_fn, Callable):  # type: ignore
+        if preprocess_x_ref and isinstance(preprocess_fn, Callable):  # type: ignore[arg-type]
             self.x_ref = preprocess_fn(x_ref)
         else:
             self.x_ref = x_ref
@@ -654,7 +667,7 @@ class BaseLSDDDrift(BaseDetector):
         self.preprocess_x_ref = preprocess_x_ref
         self.update_x_ref = update_x_ref
         self.preprocess_fn = preprocess_fn
-        self.n = len(x_ref)  # type: ignore
+        self.n = len(x_ref)
         self.n_permutations = n_permutations  # nb of iterations through permutation test
         self.n_kernel_centers = n_kernel_centers or max(self.n // 20, 1)
         self.lambda_rd_max = lambda_rd_max
@@ -676,12 +689,12 @@ class BaseLSDDDrift(BaseDetector):
         -------
         Preprocessed reference data and new instances.
         """
-        if isinstance(self.preprocess_fn, Callable):  # type: ignore
+        if isinstance(self.preprocess_fn, Callable):  # type: ignore[arg-type]
             x = self.preprocess_fn(x)
             x_ref = self.x_ref if self.preprocess_x_ref else self.preprocess_fn(self.x_ref)
-            return x_ref, x
+            return x_ref, x  # type: ignore[return-value]
         else:
-            return self.x_ref, x
+            return self.x_ref, x  # type: ignore[return-value]
 
     @abstractmethod
     def score(self, x: Union[np.ndarray, list]) -> Tuple[float, float, np.ndarray]:
@@ -719,12 +732,12 @@ class BaseLSDDDrift(BaseDetector):
         if isinstance(self.update_x_ref, dict):
             if self.preprocess_fn is not None and self.preprocess_x_ref:
                 x = self.preprocess_fn(x)
-                x = self._normalize(x)  # type: ignore
+                x = self._normalize(x)
             elif self.preprocess_fn is None:
-                x = self._normalize(x)  # type: ignore
+                x = self._normalize(x)
             else:
                 pass
-        self.x_ref = update_reference(self.x_ref, x, self.n, self.update_x_ref)
+        self.x_ref = update_reference(self.x_ref, x, self.n, self.update_x_ref)  # type: ignore[arg-type]
         # used for reservoir sampling
         self.n += len(x)  # type: ignore
 
@@ -794,7 +807,7 @@ class BaseUnivariateDrift(BaseDetector):
 
         # optionally already preprocess reference data
         self.p_val = p_val
-        if preprocess_x_ref and isinstance(preprocess_fn, Callable):  # type: ignore
+        if preprocess_x_ref and isinstance(preprocess_fn, Callable):  # type: ignore[arg-type]
             self.x_ref = preprocess_fn(x_ref)
         else:
             self.x_ref = x_ref
@@ -802,7 +815,7 @@ class BaseUnivariateDrift(BaseDetector):
         self.update_x_ref = update_x_ref
         self.preprocess_fn = preprocess_fn
         self.correction = correction
-        self.n = len(x_ref)  # type: ignore
+        self.n = len(x_ref)
 
         # store input shape for save and load functionality
         self.input_shape = get_input_shape(input_shape, x_ref)
@@ -837,12 +850,12 @@ class BaseUnivariateDrift(BaseDetector):
         -------
         Preprocessed reference data and new instances.
         """
-        if isinstance(self.preprocess_fn, Callable):  # type: ignore
+        if isinstance(self.preprocess_fn, Callable):  # type: ignore[arg-type]
             x = self.preprocess_fn(x)
             x_ref = self.x_ref if self.preprocess_x_ref else self.preprocess_fn(self.x_ref)
-            return x_ref, x
+            return x_ref, x  # type: ignore[return-value]
         else:
-            return self.x_ref, x
+            return self.x_ref, x  # type: ignore[return-value]
 
     @abstractmethod
     def feature_score(self, x_ref: np.ndarray, x: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
@@ -900,18 +913,18 @@ class BaseUnivariateDrift(BaseDetector):
             drift_pred = (p_vals < self.p_val).astype(int)
         elif drift_type == 'batch' and self.correction == 'bonferroni':
             threshold = self.p_val / self.n_features
-            drift_pred = int((p_vals < threshold).any())
+            drift_pred = int((p_vals < threshold).any())  # type: ignore[assignment]
         elif drift_type == 'batch' and self.correction == 'fdr':
-            drift_pred, threshold = fdr(p_vals, q_val=self.p_val)
+            drift_pred, threshold = fdr(p_vals, q_val=self.p_val)  # type: ignore[assignment]
         else:
             raise ValueError('`drift_type` needs to be either `feature` or `batch`.')
 
         # update reference dataset
         if isinstance(self.update_x_ref, dict) and self.preprocess_fn is not None and self.preprocess_x_ref:
             x = self.preprocess_fn(x)
-        self.x_ref = update_reference(self.x_ref, x, self.n, self.update_x_ref)
+        self.x_ref = update_reference(self.x_ref, x, self.n, self.update_x_ref)  # type: ignore[arg-type]
         # used for reservoir sampling
-        self.n += len(x)  # type: ignore
+        self.n += len(x)
 
         # populate drift dict
         cd = concept_drift_dict()

--- a/alibi_detect/cd/base.py
+++ b/alibi_detect/cd/base.py
@@ -381,7 +381,7 @@ class BaseLearnedKernelDrift(BaseDetector):
 
         if isinstance(x_ref, np.ndarray):
             x_ref_tr, x_ref_te = x_ref[idx_ref_tr], x_ref[idx_ref_te]
-            x_cur_tr, x_cur_te = x[idx_cur_tr], x[idx_cur_te]
+            x_cur_tr, x_cur_te = x[idx_cur_tr], x[idx_cur_te]  # type: ignore[call-overload]
         elif isinstance(x, list):
             x_ref_tr, x_ref_te = [x_ref[_] for _ in idx_ref_tr], [x_ref[_] for _ in idx_ref_te]
             x_cur_tr, x_cur_te = [x[_] for _ in idx_cur_tr], [x[_] for _ in idx_cur_te]

--- a/alibi_detect/cd/base_online.py
+++ b/alibi_detect/cd/base_online.py
@@ -121,8 +121,8 @@ class BaseMultiDriftOnline(BaseDetector):
 
     def _initialise(self) -> None:
         self.t = 0  # corresponds to a test set of ref data
-        self.test_stats = np.array([])
-        self.drift_preds = np.array([])
+        self.test_stats = np.array([])  # type: ignore[var-annotated]
+        self.drift_preds = np.array([])  # type: ignore[var-annotated]
         self._configure_ref_subset()
 
     def reset(self) -> None:
@@ -320,7 +320,7 @@ class BaseUniDriftOnline(BaseDetector):
     def _initialise(self) -> None:
         self.t = 0
         self.test_stats = np.empty([0, len(self.window_sizes), self.n_features])
-        self.drift_preds = np.array([])
+        self.drift_preds = np.array([])  # type: ignore[var-annotated]
         self._configure_ref()
 
     @abstractmethod

--- a/alibi_detect/cd/model_uncertainty.py
+++ b/alibi_detect/cd/model_uncertainty.py
@@ -125,8 +125,8 @@ class ClassifierUncertaintyDrift:
         self.meta = self._detector.meta
         self.meta['name'] = 'ClassifierUncertaintyDrift'
 
-    def predict(self, x: Union[np.ndarray, list],  return_p_val: bool = True,
-                return_distance: bool = True) -> Dict[Dict[str, str], Dict[str, Union[int, float]]]:
+    def predict(self, x: Union[np.ndarray, list], return_p_val: bool = True,
+                return_distance: bool = True) -> Dict[Dict[str, str], Dict[str, Union[np.ndarray, int, float]]]:
         """
         Predict whether a batch of data has drifted from the reference data.
 
@@ -260,8 +260,8 @@ class RegressorUncertaintyDrift:
         self.meta = self._detector.meta
         self.meta['name'] = 'RegressorUncertaintyDrift'
 
-    def predict(self, x: Union[np.ndarray, list],  return_p_val: bool = True,
-                return_distance: bool = True) -> Dict[Dict[str, str], Dict[str, Union[int, float]]]:
+    def predict(self, x: Union[np.ndarray, list], return_p_val: bool = True,
+                return_distance: bool = True) -> Dict[Dict[str, str], Dict[str, Union[np.ndarray, int, float]]]:
         """
         Predict whether a batch of data has drifted from the reference data.
 

--- a/alibi_detect/cd/pytorch/lsdd.py
+++ b/alibi_detect/cd/pytorch/lsdd.py
@@ -1,6 +1,6 @@
 import numpy as np
 import torch
-from typing import Callable, Dict, Optional, Tuple, Union, cast
+from typing import Callable, Dict, Optional, Tuple, Union
 from alibi_detect.cd.base import BaseLSDDDrift
 from alibi_detect.utils.pytorch.kernels import GaussianRBF
 from alibi_detect.utils.pytorch.distance import permed_lsdds

--- a/alibi_detect/cd/pytorch/lsdd_online.py
+++ b/alibi_detect/cd/pytorch/lsdd_online.py
@@ -91,12 +91,13 @@ class LSDDDriftOnlineTorch(BaseMultiDriftOnline):
 
         # initialize kernel
         if sigma is None:
-            x_ref = torch.from_numpy(self.x_ref).to(self.device)
+            x_ref = torch.from_numpy(self.x_ref).to(self.device)  # type: ignore[assignment]
             self.kernel = GaussianRBF()
             _ = self.kernel(x_ref, x_ref, infer_sigma=True)
         else:
-            sigma = torch.from_numpy(sigma).to(self.device) if isinstance(sigma, np.ndarray) else None
-            self.kernel = GaussianRBF(sigma)
+            sigma = torch.from_numpy(sigma).to(self.device) \
+                if isinstance(sigma, np.ndarray) else None  # type: ignore[assignment]
+            self.kernel = GaussianRBF(sigma)  # type: ignore[arg-type]
 
         if self.n_kernel_centers is None:
             self.n_kernel_centers = 2 * window_size

--- a/alibi_detect/cd/pytorch/lsdd_online.py
+++ b/alibi_detect/cd/pytorch/lsdd_online.py
@@ -99,7 +99,7 @@ class LSDDDriftOnlineTorch(BaseMultiDriftOnline):
             self.kernel = GaussianRBF(sigma)
 
         if self.n_kernel_centers is None:
-            self.n_kernel_centers = 2*window_size
+            self.n_kernel_centers = 2 * window_size
 
         self._configure_kernel_centers()
         self._configure_thresholds()
@@ -109,7 +109,7 @@ class LSDDDriftOnlineTorch(BaseMultiDriftOnline):
         x_ref = torch.from_numpy(self.x_ref).to(self.device)
         x_ref_means = x_ref.mean(0)
         x_ref_stds = x_ref.std(0)
-        self._normalize = lambda x: (x - x_ref_means)/(x_ref_stds + eps)
+        self._normalize = lambda x: (x - x_ref_means) / (x_ref_stds + eps)
         self.x_ref = self._normalize(x_ref).cpu().numpy()
 
     def _configure_kernel_centers(self):
@@ -118,7 +118,7 @@ class LSDDDriftOnlineTorch(BaseMultiDriftOnline):
         self.c_inds, self.non_c_inds = perm[:self.n_kernel_centers], perm[self.n_kernel_centers:]
         self.kernel_centers = torch.from_numpy(self.x_ref[self.c_inds]).to(self.device)
         if np.unique(self.kernel_centers.cpu().numpy(), axis=0).shape[0] < self.n_kernel_centers:
-            perturbation = (torch.randn(self.kernel_centers.shape)*1e-6).to(self.device)
+            perturbation = (torch.randn(self.kernel_centers.shape) * 1e-6).to(self.device)
             self.kernel_centers = self.kernel_centers + perturbation
         self.x_ref_eff = torch.from_numpy(self.x_ref[self.non_c_inds]).to(self.device)  # the effective reference set
         self.k_xc = self.kernel(self.x_ref_eff, self.kernel_centers)
@@ -130,7 +130,7 @@ class LSDDDriftOnlineTorch(BaseMultiDriftOnline):
         # test windows of size W (so 2W-1 test samples in total)
 
         w_size = self.window_size
-        etw_size = 2*w_size-1  # etw = extended test window
+        etw_size = 2 * w_size - 1  # etw = extended test window
         nkc_size = self.n - self.n_kernel_centers  # nkc = non-kernel-centers
         rw_size = nkc_size - etw_size  # rw = ref-window
 
@@ -140,7 +140,7 @@ class LSDDDriftOnlineTorch(BaseMultiDriftOnline):
 
         # For stability in high dimensions we don't divide H by (pi*sigma^2)^(d/2)
         # Results in an alternative test-stat of LSDD*(pi*sigma^2)^(d/2). Same p-vals etc.
-        H = GaussianRBF(np.sqrt(2.)*self.kernel.sigma)(self.kernel_centers, self.kernel_centers)
+        H = GaussianRBF(np.sqrt(2.) * self.kernel.sigma)(self.kernel_centers, self.kernel_centers)
 
         # Compute lsdds for first test-window. We infer regularisation constant lambda here.
         y_inds_all_0 = [y_inds[:w_size] for y_inds in y_inds_all]
@@ -149,13 +149,13 @@ class LSDDDriftOnlineTorch(BaseMultiDriftOnline):
         )
 
         # Can compute threshold for first window
-        thresholds = [quantile(lsdds_0, 1-self.fpr)]
+        thresholds = [quantile(lsdds_0, 1 - self.fpr)]
         # And now to iterate through the other W-1 overlapping windows
         p_bar = tqdm(range(1, w_size), "Computing thresholds") if self.verbose else range(1, w_size)
         for w in p_bar:
-            y_inds_all_w = [y_inds[w:(w+w_size)] for y_inds in y_inds_all]
+            y_inds_all_w = [y_inds[w:(w + w_size)] for y_inds in y_inds_all]
             lsdds_w, _ = permed_lsdds(self.k_xc, x_inds_all, y_inds_all_w, H, H_lam_inv=H_lam_inv)
-            thresholds.append(quantile(lsdds_w, 1-self.fpr))
+            thresholds.append(quantile(lsdds_w, 1 - self.fpr))
             x_inds_all = [x_inds_all[i] for i in range(len(x_inds_all)) if lsdds_w[i] < thresholds[-1]]
             y_inds_all = [y_inds_all[i] for i in range(len(y_inds_all)) if lsdds_w[i] < thresholds[-1]]
 
@@ -163,7 +163,7 @@ class LSDDDriftOnlineTorch(BaseMultiDriftOnline):
         self.H_lam_inv = H_lam_inv
 
     def _configure_ref_subset(self):
-        etw_size = 2*self.window_size-1  # etw = extended test window
+        etw_size = 2 * self.window_size - 1  # etw = extended test window
         nkc_size = self.n - self.n_kernel_centers  # nkc = non-kernel-centers
         rw_size = nkc_size - etw_size  # rw = ref-window
         # Make split and ensure it doesn't cause an initial detection
@@ -179,11 +179,11 @@ class LSDDDriftOnlineTorch(BaseMultiDriftOnline):
             h_init = self.c2s - self.k_xtc.mean(0)  # (Eqn 21)
             lsdd_init = h_init[None, :] @ self.H_lam_inv @ h_init[:, None]  # (Eqn 11)
 
-    def _update_state(self, x_t: torch.Tensor):
+    def _update_state(self, x_t: torch.Tensor):  # type: ignore[override]
         self.t += 1
         k_xtc = self.kernel(x_t, self.kernel_centers)
-        self.test_window = torch.cat([self.test_window[(1-self.window_size):], x_t], 0)
-        self.k_xtc = torch.cat([self.k_xtc[(1-self.window_size):], k_xtc], 0)
+        self.test_window = torch.cat([self.test_window[(1 - self.window_size):], x_t], 0)
+        self.k_xtc = torch.cat([self.k_xtc[(1 - self.window_size):], k_xtc], 0)
 
     def score(self, x_t: Union[np.ndarray, Any]) -> float:
         """

--- a/alibi_detect/cd/pytorch/mmd.py
+++ b/alibi_detect/cd/pytorch/mmd.py
@@ -82,7 +82,8 @@ class MMDDriftTorch(BaseMMDDrift):
             self.device = torch.device('cpu')
 
         # initialize kernel
-        sigma = torch.from_numpy(sigma).to(self.device) if isinstance(sigma, np.ndarray) else None
+        sigma = torch.from_numpy(sigma).to(self.device) \
+            if isinstance(sigma, np.ndarray) else None  # type: ignore[assignment]
         self.kernel = kernel(sigma) if kernel == GaussianRBF else kernel
 
         # compute kernel matrix for the reference data
@@ -117,11 +118,11 @@ class MMDDriftTorch(BaseMMDDrift):
         and the MMD^2 values from the permutation test.
         """
         x_ref, x = self.preprocess(x)
-        x_ref = torch.from_numpy(x_ref).to(self.device)
-        x = torch.from_numpy(x).to(self.device)
+        x_ref = torch.from_numpy(x_ref).to(self.device)  # type: ignore[assignment]
+        x = torch.from_numpy(x).to(self.device)  # type: ignore[assignment]
         # compute kernel matrix, MMD^2 and apply permutation test using the kernel matrix
         n = x.shape[0]
-        kernel_mat = self.kernel_matrix(x_ref, x)
+        kernel_mat = self.kernel_matrix(x_ref, x)  # type: ignore[arg-type]
         kernel_mat = kernel_mat - torch.diag(kernel_mat.diag())  # zero diagonal
         mmd2 = mmd2_from_kernel_matrix(kernel_mat, n, permute=False, zero_diag=False)
         mmd2_permuted = torch.Tensor(

--- a/alibi_detect/cd/pytorch/mmd_online.py
+++ b/alibi_detect/cd/pytorch/mmd_online.py
@@ -152,9 +152,9 @@ class MMDDriftOnlineTorch(BaseMultiDriftOnline):
             mmds = [(
                     k_xx_sum +
                     zero_diag(self.k_xx[y_inds_w][:, y_inds_w]).sum() / (w_size * (w_size - 1)) -
-                    2 * k_xy_col_sums[w:w + w_size].sum()
-            ) for k_xx_sum, y_inds_w, k_xy_col_sums in zip(k_xx_sums_all, y_inds_all_w, k_xy_col_sums_all)
-            ]
+                    2 * k_xy_col_sums[w:w + w_size].sum())
+                    for k_xx_sum, y_inds_w, k_xy_col_sums in zip(k_xx_sums_all, y_inds_all_w, k_xy_col_sums_all)
+                    ]
             mmds = torch.tensor(mmds)  # an mmd for each bootstrap sample
 
             # Now we discard all bootstrap samples for which mmd is in top (1/ert)% and record the thresholds

--- a/alibi_detect/cd/pytorch/preprocess.py
+++ b/alibi_detect/cd/pytorch/preprocess.py
@@ -1,8 +1,10 @@
+from typing import Callable, Optional, Type, Union
+
 import numpy as np
 import torch
 import torch.nn as nn
-from typing import Callable, Optional, Union
-from alibi_detect.utils.pytorch.prediction import predict_batch, predict_batch_transformer
+from alibi_detect.utils.pytorch.prediction import (predict_batch,
+                                                   predict_batch_transformer)
 
 
 class HiddenOutput(nn.Module):
@@ -25,8 +27,8 @@ class HiddenOutput(nn.Module):
 def preprocess_drift(x: Union[np.ndarray, list], model: Union[nn.Module, nn.Sequential],
                      device: Optional[torch.device] = None, preprocess_batch_fn: Callable = None,
                      tokenizer: Optional[Callable] = None, max_len: Optional[int] = None,
-                     batch_size: int = int(1e10), dtype: np.dtype = np.float32) \
-        -> Union[np.ndarray, torch.Tensor]:
+                     batch_size: int = int(1e10), dtype: Union[Type[np.generic], torch.dtype] = np.float32) \
+        -> Union[np.ndarray, torch.Tensor, tuple]:
     """
     Prediction function used for preprocessing step of drift detector.
 

--- a/alibi_detect/cd/tensorflow/classifier.py
+++ b/alibi_detect/cd/tensorflow/classifier.py
@@ -123,7 +123,7 @@ class ClassifierDriftTF(BaseClassifierDrift):
         if isinstance(train_kwargs, dict):
             self.train_kwargs.update(train_kwargs)
 
-    def score(self, x: np.ndarray) -> Tuple[float, float, np.ndarray, np.ndarray]:
+    def score(self, x: np.ndarray) -> Tuple[float, float, np.ndarray, np.ndarray]:  # type: ignore[override]
         """
         Compute the out-of-fold drift metric such as the accuracy from a classifier
         trained to distinguish the reference data from the data to be tested.

--- a/alibi_detect/cd/tensorflow/classifier.py
+++ b/alibi_detect/cd/tensorflow/classifier.py
@@ -139,9 +139,9 @@ class ClassifierDriftTF(BaseClassifierDrift):
         and that which we'd expect under the null assumption of no drift,
         and the out-of-fold classifier model prediction probabilities on the reference and test data
         """
-        x_ref, x = self.preprocess(x)
+        x_ref, x = self.preprocess(x)  # type: ignore[assignment]
         n_ref, n_cur = len(x_ref), len(x)
-        x, y, splits = self.get_splits(x_ref, x)
+        x, y, splits = self.get_splits(x_ref, x)  # type: ignore[assignment]
 
         # iterate over folds: train a new model for each fold and make out-of-fold (oof) predictions
         preds_oof_list, idx_oof_list = [], []

--- a/alibi_detect/cd/tensorflow/lsdd.py
+++ b/alibi_detect/cd/tensorflow/lsdd.py
@@ -77,10 +77,10 @@ class LSDDDriftTF(BaseLSDDDrift):
             x_ref = self._normalize(x_ref)
             self._initialize_kernel(x_ref)
             self._configure_kernel_centers(x_ref)
-            self.x_ref = x_ref.numpy()
+            self.x_ref = x_ref.numpy()  # type: ignore[union-attr]
             # For stability in high dimensions we don't divide H by (pi*sigma^2)^(d/2)
             # Results in an alternative test-stat of LSDD*(pi*sigma^2)^(d/2). Same p-vals etc.
-            self.H = GaussianRBF(np.sqrt(2.)*self.kernel.sigma)(self.kernel_centers, self.kernel_centers)
+            self.H = GaussianRBF(np.sqrt(2.) * self.kernel.sigma)(self.kernel_centers, self.kernel_centers)
 
     def _initialize_kernel(self, x_ref: tf.Tensor):
         if self.sigma is None:
@@ -93,7 +93,7 @@ class LSDDDriftTF(BaseLSDDDrift):
     def _configure_normalization(self, x_ref: tf.Tensor, eps: float = 1e-12):
         x_ref_means = tf.reduce_mean(x_ref, axis=0)
         x_ref_stds = tf.math.reduce_std(x_ref, axis=0)
-        self._normalize = lambda x: (x - x_ref_means)/(x_ref_stds + eps)
+        self._normalize = lambda x: (x - x_ref_means) / (x_ref_stds + eps)  # type: ignore[assignment]
 
     def _configure_kernel_centers(self, x_ref: tf.Tensor):
         "Set aside reference samples to act as kernel centers"
@@ -128,7 +128,7 @@ class LSDDDriftTF(BaseLSDDDrift):
             x_ref = self._normalize(x_ref)
             self._initialize_kernel(x_ref)
             self._configure_kernel_centers(x_ref)
-            self.H = GaussianRBF(np.sqrt(2.)*self.kernel.sigma)(self.kernel_centers, self.kernel_centers)
+            self.H = GaussianRBF(np.sqrt(2.) * self.kernel.sigma)(self.kernel_centers, self.kernel_centers)
 
         x = self._normalize(x)
 

--- a/alibi_detect/cd/tensorflow/mmd_online.py
+++ b/alibi_detect/cd/tensorflow/mmd_online.py
@@ -158,7 +158,7 @@ class MMDDriftOnlineTF(BaseMultiDriftOnline):
 
         self.thresholds = thresholds
 
-    def _update_state(self, x_t: np.ndarray):
+    def _update_state(self, x_t: np.ndarray): # type: ignore[override]
         self.t += 1
         kernel_col = self.kernel(self.x_ref[self.ref_inds], x_t)
         self.test_window = tf.concat([self.test_window[(1-self.window_size):], x_t], axis=0)

--- a/alibi_detect/cd/tensorflow/mmd_online.py
+++ b/alibi_detect/cd/tensorflow/mmd_online.py
@@ -78,7 +78,7 @@ class MMDDriftOnlineTF(BaseMultiDriftOnline):
         self._initialise()
 
     def _configure_ref_subset(self):
-        etw_size = 2*self.window_size-1  # etw = extended test window
+        etw_size = 2 * self.window_size - 1  # etw = extended test window
         rw_size = self.n - etw_size  # rw = ref window#
         # Make split and ensure it doesn't cause an initial detection
         mmd_init = None
@@ -89,13 +89,13 @@ class MMDDriftOnlineTF(BaseMultiDriftOnline):
             self.test_window = tf.gather(self.x_ref, self.init_test_inds)
             # Compute initial mmd to check for initial detection
             self.k_xx_sub = subset_matrix(self.k_xx, self.ref_inds, self.ref_inds)
-            self.k_xx_sub_sum = tf.reduce_sum(zero_diag(self.k_xx_sub))/(rw_size*(rw_size-1))
+            self.k_xx_sub_sum = tf.reduce_sum(zero_diag(self.k_xx_sub)) / (rw_size * (rw_size - 1))
             self.k_xy = self.kernel(tf.gather(self.x_ref, self.ref_inds), self.test_window)
             k_yy = self.kernel(self.test_window, self.test_window)
             mmd_init = (
-                self.k_xx_sub_sum +
-                tf.reduce_sum(zero_diag(k_yy))/(self.window_size*(self.window_size-1)) -
-                2*tf.reduce_mean(self.k_xy)
+                    self.k_xx_sub_sum +
+                    tf.reduce_sum(zero_diag(k_yy)) / (self.window_size * (self.window_size - 1)) -
+                    2 * tf.reduce_mean(self.k_xy)
             )
 
     def _configure_thresholds(self):
@@ -105,7 +105,7 @@ class MMDDriftOnlineTF(BaseMultiDriftOnline):
         # test windows of size W (so 2W-1 test samples in total)
 
         w_size = self.window_size
-        etw_size = 2*w_size-1  # etw = extended test window
+        etw_size = 2 * w_size - 1  # etw = extended test window
         rw_size = self.n - etw_size  # rw = ref window
 
         perms = [tf.random.shuffle(tf.range(self.n)) for _ in range(self.n_bootstraps)]
@@ -124,30 +124,30 @@ class MMDDriftOnlineTF(BaseMultiDriftOnline):
         k_xy_col_sums_all = [
             tf.reduce_sum(subset_matrix(self.k_xx, x_inds, y_inds), axis=0) for x_inds, y_inds in
             (tqdm(zip(x_inds_all, y_inds_all), total=self.n_bootstraps) if self.verbose else
-                zip(x_inds_all, y_inds_all))
+             zip(x_inds_all, y_inds_all))
         ]
         k_xx_sums_all = [(
-            k_full_sum -
-            tf.reduce_sum(zero_diag(subset_matrix(self.k_xx, y_inds, y_inds))) -
-            2*tf.reduce_sum(k_xy_col_sums)
-        )/(rw_size*(rw_size-1)) for y_inds, k_xy_col_sums in zip(y_inds_all, k_xy_col_sums_all)]
-        k_xy_col_sums_all = [k_xy_col_sums/(rw_size*w_size) for k_xy_col_sums in k_xy_col_sums_all]
+                                 k_full_sum -
+                                 tf.reduce_sum(zero_diag(subset_matrix(self.k_xx, y_inds, y_inds))) -
+                                 2 * tf.reduce_sum(k_xy_col_sums)
+                         ) / (rw_size * (rw_size - 1)) for y_inds, k_xy_col_sums in zip(y_inds_all, k_xy_col_sums_all)]
+        k_xy_col_sums_all = [k_xy_col_sums / (rw_size * w_size) for k_xy_col_sums in k_xy_col_sums_all]
 
         # Now to iterate through the W overlapping windows
         thresholds = []
         p_bar = tqdm(range(w_size), "Computing thresholds") if self.verbose else range(w_size)
         for w in p_bar:
-            y_inds_all_w = [y_inds[w:w+w_size] for y_inds in y_inds_all]  # test windows of size W
+            y_inds_all_w = [y_inds[w:w + w_size] for y_inds in y_inds_all]  # test windows of size W
             mmds = [(
-                k_xx_sum +
-                tf.reduce_sum(zero_diag(subset_matrix(self.k_xx, y_inds_w, y_inds_w)))/(w_size*(w_size-1)) -
-                2*tf.reduce_sum(k_xy_col_sums[w:w+w_size])
-            ) for k_xx_sum, y_inds_w, k_xy_col_sums in zip(k_xx_sums_all, y_inds_all_w, k_xy_col_sums_all)
-            ]
+                    k_xx_sum +
+                    tf.reduce_sum(zero_diag(subset_matrix(self.k_xx, y_inds_w, y_inds_w))) / (w_size * (w_size - 1)) -
+                    2 * tf.reduce_sum(k_xy_col_sums[w:w + w_size]))
+                    for k_xx_sum, y_inds_w, k_xy_col_sums in zip(k_xx_sums_all, y_inds_all_w, k_xy_col_sums_all)
+                    ]
             mmds = tf.concat(mmds, axis=0)  # an mmd for each bootstrap sample
 
             # Now we discard all bootstrap samples for which mmd is in top (1/ert)% and record the thresholds
-            thresholds.append(quantile(mmds, 1-self.fpr))
+            thresholds.append(quantile(mmds, 1 - self.fpr))
             y_inds_all = [y_inds_all[i] for i in range(len(y_inds_all)) if mmds[i] < thresholds[-1]]
             k_xx_sums_all = [
                 k_xx_sums_all[i] for i in range(len(k_xx_sums_all)) if mmds[i] < thresholds[-1]
@@ -158,11 +158,11 @@ class MMDDriftOnlineTF(BaseMultiDriftOnline):
 
         self.thresholds = thresholds
 
-    def _update_state(self, x_t: np.ndarray): # type: ignore[override]
+    def _update_state(self, x_t: np.ndarray):  # type: ignore[override]
         self.t += 1
         kernel_col = self.kernel(self.x_ref[self.ref_inds], x_t)
-        self.test_window = tf.concat([self.test_window[(1-self.window_size):], x_t], axis=0)
-        self.k_xy = tf.concat([self.k_xy[:, (1-self.window_size):], kernel_col], axis=1)
+        self.test_window = tf.concat([self.test_window[(1 - self.window_size):], x_t], axis=0)
+        self.k_xy = tf.concat([self.k_xy[:, (1 - self.window_size):], kernel_col], axis=1)
 
     def score(self, x_t: Union[np.ndarray, Any]) -> float:
         """
@@ -181,8 +181,8 @@ class MMDDriftOnlineTF(BaseMultiDriftOnline):
         self._update_state(x_t)
         k_yy = self.kernel(self.test_window, self.test_window)
         mmd = (
-            self.k_xx_sub_sum +
-            tf.reduce_sum(zero_diag(k_yy))/(self.window_size*(self.window_size-1)) -
-            2*tf.reduce_mean(self.k_xy)
+                self.k_xx_sub_sum +
+                tf.reduce_sum(zero_diag(k_yy)) / (self.window_size * (self.window_size - 1)) -
+                2 * tf.reduce_mean(self.k_xy)
         )
         return mmd.numpy()

--- a/alibi_detect/cd/tensorflow/preprocess.py
+++ b/alibi_detect/cd/tensorflow/preprocess.py
@@ -1,9 +1,11 @@
+from typing import Callable, Dict, Optional, Type, Union
+
 import numpy as np
 import tensorflow as tf
+from alibi_detect.utils.tensorflow.prediction import (
+    predict_batch, predict_batch_transformer)
 from tensorflow.keras.layers import Dense, Flatten, Input, InputLayer
 from tensorflow.keras.models import Model
-from typing import Callable, Dict, Optional, Union
-from alibi_detect.utils.tensorflow.prediction import predict_batch, predict_batch_transformer
 
 
 class _Encoder(tf.keras.Model):
@@ -85,7 +87,7 @@ class HiddenOutput(tf.keras.Model):
 
 def preprocess_drift(x: Union[np.ndarray, list], model: tf.keras.Model,
                      preprocess_batch_fn: Callable = None, tokenizer: Callable = None,
-                     max_len: int = None, batch_size: int = int(1e10), dtype: np.dtype = np.float32) \
+                     max_len: int = None, batch_size: int = int(1e10), dtype: Type[np.generic] = np.float32) \
         -> Union[np.ndarray, tf.Tensor]:
     """
     Prediction function used for preprocessing step of drift detector.

--- a/alibi_detect/cd/tensorflow/tests/test_classifier_tf.py
+++ b/alibi_detect/cd/tensorflow/tests/test_classifier_tf.py
@@ -19,7 +19,7 @@ def mymodel(shape, softmax: bool = True):
 
 
 # test List[Any] inputs to the detector
-def identity_fn(x: Union[np.array, list]) -> np.array:
+def identity_fn(x: Union[np.ndarray, list]) -> np.ndarray:
     if isinstance(x, list):
         return np.array(x)
     else:

--- a/alibi_detect/cd/tensorflow/tests/test_learned_kernel_tf.py
+++ b/alibi_detect/cd/tensorflow/tests/test_learned_kernel_tf.py
@@ -27,7 +27,7 @@ class MyKernel(tf.keras.Model):  # TODO: Support then test models using keras fu
 
 
 # test List[Any] inputs to the detector
-def identity_fn(x: Union[np.array, list]) -> np.array:
+def identity_fn(x: Union[np.ndarray, list]) -> np.ndarray:
     if isinstance(x, list):
         return np.array(x)
     else:

--- a/alibi_detect/cd/tensorflow/tests/test_spot_the_diff_tf.py
+++ b/alibi_detect/cd/tensorflow/tests/test_spot_the_diff_tf.py
@@ -27,7 +27,7 @@ class MyKernel(tf.keras.Model):  # TODO: Support then test models using keras fu
 
 
 # test List[Any] inputs to the detector
-def identity_fn(x: Union[np.array, list]) -> np.array:
+def identity_fn(x: Union[np.ndarray, list]) -> np.ndarray:
     if isinstance(x, list):
         return np.array(x)
     else:

--- a/alibi_detect/cd/tests/test_model_uncertainty.py
+++ b/alibi_detect/cd/tests/test_model_uncertainty.py
@@ -43,7 +43,7 @@ class PtModel(nn.Module):
 def dumb_model(x, n_labels, softmax=False):
     if isinstance(x, list):
         x = np.concatenate(x, axis=0)
-    x = np.stack([np.mean(x*(i+1), axis=-1) for i in range(n_labels)], axis=-1)
+    x = np.stack([np.mean(x * (i + 1), axis=-1) for i in range(n_labels)], axis=-1)
     if softmax:
         x = scipy.special.softmax(x, axis=-1)
     return x
@@ -63,7 +63,7 @@ def id_fn(x: list, to_pt: bool = False) -> Union[np.ndarray, torch.Tensor]:
     if to_pt:
         return torch.from_numpy(x)
     else:
-        return x
+        return x  # type: ignore[return-value]
 
 
 p_val = [.05]

--- a/alibi_detect/cd/utils.py
+++ b/alibi_detect/cd/utils.py
@@ -1,7 +1,8 @@
 import logging
-import numpy as np
 import random
-from typing import Dict, Callable, Optional, Tuple, Union
+from typing import Callable, Dict, Optional, Tuple, Union
+
+import numpy as np
 from alibi_detect.utils.sampling import reservoir_sampling
 
 logger = logging.getLogger(__name__)
@@ -46,13 +47,13 @@ def update_reference(X_ref: np.ndarray,
 
 
 def encompass_batching(
-    model: Callable,
-    backend: str,
-    batch_size: int,
-    device: Optional[str] = None,
-    preprocess_batch_fn: Optional[Callable] = None,
-    tokenizer: Optional[Callable] = None,
-    max_len: Optional[int] = None,
+        model: Callable,
+        backend: str,
+        batch_size: int,
+        device: Optional[str] = None,
+        preprocess_batch_fn: Optional[Callable] = None,
+        tokenizer: Optional[Callable] = None,
+        max_len: Optional[int] = None,
 ) -> Callable:
     """
     Takes a function that must be batch evaluated (on tokenized input) and returns a function
@@ -65,20 +66,20 @@ def encompass_batching(
     if backend == 'tensorflow':
         from alibi_detect.cd.tensorflow.preprocess import preprocess_drift
     elif backend == 'pytorch':
-        from alibi_detect.cd.pytorch.preprocess import preprocess_drift  # type: ignore
+        from alibi_detect.cd.pytorch.preprocess import preprocess_drift  # type: ignore[no-redef]
         kwargs['device'] = device
     else:
         raise NotImplementedError(f'{backend} not implemented. Use tensorflow or pytorch instead.')
 
     def model_fn(x: Union[np.ndarray, list]) -> np.ndarray:
-        return preprocess_drift(x, model, **kwargs)  # type: ignore
+        return preprocess_drift(x, model, **kwargs)  # type: ignore[arg-type]
 
     return model_fn
 
 
 def encompass_shuffling_and_batch_filling(
-    model_fn: Callable,
-    batch_size: int
+        model_fn: Callable,
+        batch_size: int
 ) -> Callable:
     """
     Takes a function that already handles batching but additionally performing shuffling
@@ -90,13 +91,13 @@ def encompass_shuffling_and_batch_filling(
         # shuffle
         n_x = len(x)
         perm = np.random.permutation(n_x)
-        x = x[perm] if is_np else [x[i] for i in perm]
+        x = x[perm] if is_np else [x[i] for i in perm]  # type: ignore[call-overload]
         # add extras if necessary
         final_batch_size = n_x % batch_size
         if final_batch_size != 0:
             doubles_inds = random.choices([i for i in range(n_x)], k=batch_size - final_batch_size)
             if is_np:
-                x = np.concatenate([x, x[doubles_inds]], axis=0)  # type: ignore
+                x = np.concatenate([x, x[doubles_inds]], axis=0)  # type: ignore[call-overload]
             else:
                 x += [x[i] for i in doubles_inds]
         # remove any extras and unshuffle

--- a/alibi_detect/datasets.py
+++ b/alibi_detect/datasets.py
@@ -1,17 +1,18 @@
-import dill
 import io
-from io import BytesIO
 import logging
-import numpy as np
 import os
+from io import BytesIO
+from typing import List, Tuple, Type, Union
+from xml.etree import ElementTree
+
+import dill
+import numpy as np
 import pandas as pd
 import requests
+from alibi_detect.utils.data import Bunch
 from requests import RequestException
 from scipy.io import arff
 from sklearn.datasets import fetch_kddcup99
-from typing import List, Tuple, Union
-from xml.etree import ElementTree
-from alibi_detect.utils.data import Bunch
 
 # do not extend pickle dispatch table so as not to change pickle behaviour
 dill.extend(use_dill=False)
@@ -112,7 +113,7 @@ def fetch_kdd(target: list = ['dos', 'r2l', 'u2r', 'probe'],
                  feature_names=keep_cols)
 
 
-def load_url_arff(url: str, dtype: Union[str, np.dtype] = np.float32) -> np.ndarray:
+def load_url_arff(url: str, dtype: Type[np.generic] = np.float32) -> np.ndarray:
     """
     Load arff files from url.
 

--- a/alibi_detect/od/ae.py
+++ b/alibi_detect/od/ae.py
@@ -197,7 +197,7 @@ class OutlierAE(BaseDetector, FitMixin, ThresholdMixin):
         X_recon = predict_batch(X, self.ae, batch_size=batch_size)
 
         # compute feature and instance level scores
-        fscore = self.feature_score(X, X_recon)
+        fscore = self.feature_score(X, X_recon)  # type: ignore[arg-type]
         iscore = self.instance_score(fscore, outlier_perc=outlier_perc)
 
         return fscore, iscore

--- a/alibi_detect/od/llr.py
+++ b/alibi_detect/od/llr.py
@@ -184,12 +184,12 @@ class LLR(BaseDetector, FitMixin, ThresholdMixin):
             # train semantic model
             args = [self.dist_s, loss_fn, X]
             kwargs.update({'y_train': y})
-            trainer(*args, **kwargs)
+            trainer(*args, **kwargs)  # type: ignore[arg-type]
 
             # train background model
             args = [self.dist_b, loss_fn, X_back]
             kwargs.update({'y_train': y_back})
-            trainer(*args, **kwargs)
+            trainer(*args, **kwargs)  # type: ignore[arg-type]
 
     def infer_threshold(self,
                         X: np.ndarray,
@@ -245,7 +245,8 @@ class LLR(BaseDetector, FitMixin, ThresholdMixin):
         Log probabilities.
         """
         logp_fn = partial(dist.log_prob, return_per_feature=return_per_feature)
-        return predict_batch(X, logp_fn, batch_size=batch_size)
+        # TODO: TBD: can this be any of the other types from predict_batch? i.e. tf.Tensor or tuple
+        return predict_batch(X, logp_fn, batch_size=batch_size)  # type: ignore[return-value]
 
     def logp_alt(self, model: tf.keras.Model, X: np.ndarray, return_per_feature: bool = False,
                  batch_size: int = int(1e10)) -> np.ndarray:

--- a/alibi_detect/od/sr.py
+++ b/alibi_detect/od/sr.py
@@ -44,8 +44,8 @@ class SpectralResidual(BaseDetector, ThresholdMixin):
         self.threshold = threshold
         self.window_amp = window_amp
         self.window_local = window_local
-        self.conv_amp = np.ones((1, window_amp)).reshape(-1,) / window_amp
-        self.conv_local = np.ones((1, window_local)).reshape(-1,) / window_local
+        self.conv_amp = np.ones((1, window_amp)).reshape(-1, ) / window_amp
+        self.conv_local = np.ones((1, window_local)).reshape(-1, ) / window_local
         self.n_est_points = n_est_points
         self.n_grad_points = n_grad_points
 
@@ -96,7 +96,7 @@ class SpectralResidual(BaseDetector, ThresholdMixin):
         log_amp = np.log(amp)
         phase = np.angle(fft)
         ma_log_amp = np.convolve(log_amp, self.conv_amp, 'same')
-        res_amp = log_amp - ma_log_amp
+        res_amp = log_amp - ma_log_amp  # type: np.ndarray
         sr = np.abs(np.fft.ifft(np.exp(res_amp + 1j * phase)))
         return sr
 
@@ -116,8 +116,8 @@ class SpectralResidual(BaseDetector, ThresholdMixin):
         -------
         Array with slope values.
         """
-        dX = X[-1] - X[-self.n_grad_points-1:-1]
-        dt = t[-1] - t[-self.n_grad_points-1:-1]
+        dX = X[-1] - X[-self.n_grad_points - 1:-1]
+        dt = t[-1] - t[-self.n_grad_points - 1:-1]
         mean_grads = np.mean(dX / dt) * np.mean(dt)
         return mean_grads
 
@@ -162,7 +162,7 @@ class SpectralResidual(BaseDetector, ThresholdMixin):
 
         if len(X.shape) == 2:
             n_samples, n_dim = X.shape
-            X = X.reshape(-1,)
+            X = X.reshape(-1, )
             if X.shape[0] != n_samples:
                 raise ValueError('Only univariate time series allowed for SR method. Number of features '
                                  'of time series equals {}.'.format(n_dim))

--- a/alibi_detect/od/vae.py
+++ b/alibi_detect/od/vae.py
@@ -236,7 +236,7 @@ class OutlierVAE(BaseDetector, FitMixin, ThresholdMixin):
         X_recon = predict_batch(X_samples, self.vae, batch_size=batch_size)
 
         # compute feature and instance level scores
-        fscore = self.feature_score(X_samples, X_recon)
+        fscore = self.feature_score(X_samples, X_recon)  # type: ignore[arg-type]
         iscore = self.instance_score(fscore, outlier_perc=outlier_perc)
 
         return fscore, iscore

--- a/alibi_detect/utils/perturbation.py
+++ b/alibi_detect/utils/perturbation.py
@@ -131,10 +131,10 @@ def apply_mask(X: np.ndarray,
 
         for c in channels:
             mask[
-            _,
-            x_start[_]:x_start[_] + mask_size[0],
-            y_start[_]:y_start[_] + mask_size[1],
-            c
+                _,
+                x_start[_]:x_start[_] + mask_size[0],
+                y_start[_]:y_start[_] + mask_size[1],
+                c
             ] = update_val
 
     # apply masks to instances

--- a/alibi_detect/utils/perturbation.py
+++ b/alibi_detect/utils/perturbation.py
@@ -1,6 +1,6 @@
 import random
 from io import BytesIO
-from typing import List, Tuple, Union, cast
+from typing import List, Tuple
 
 import cv2
 import numpy as np

--- a/alibi_detect/utils/perturbation.py
+++ b/alibi_detect/utils/perturbation.py
@@ -131,10 +131,10 @@ def apply_mask(X: np.ndarray,
 
         for c in channels:
             mask[
-                _,
-                x_start[_]:x_start[_] + mask_size[0],
-                y_start[_]:y_start[_] + mask_size[1],
-                c
+            _,
+            x_start[_]:x_start[_] + mask_size[0],
+            y_start[_]:y_start[_] + mask_size[1],
+            c
             ] = update_val
 
     # apply masks to instances
@@ -201,7 +201,7 @@ def inject_outlier_ts(X: np.ndarray,
         X_outlier[outlier_idx, s] += np.sign(rnd) * np.maximum(np.abs(rnd * n_std), min_std) * stdev
         is_outlier[outlier_idx] = 1
     if n_dim == 1:
-        X_outlier = X_outlier.reshape(n_samples,)
+        X_outlier = X_outlier.reshape(n_samples, )
     return Bunch(data=X_outlier, target=is_outlier, target_names=['normal', 'outlier'])
 
 
@@ -377,6 +377,7 @@ def inject_outlier_categorical(X: np.ndarray,
                  cat_perturb=cat_perturb,
                  d_abs=d_abs,
                  target_names=['normal', 'outlier'])
+
 
 # Note: the perturbation functions below are adopted from
 # https://github.com/hendrycks/robustness/blob/master/ImageNet-C/imagenet_c/imagenet_c/corruptions.py
@@ -666,8 +667,8 @@ def disk(radius: float, alias_blur: float = 0.1, dtype=np.float32) -> np.ndarray
     -------
     Kernel used for Gaussian blurring.
     """
-    if radius <= 8:
-        L = np.arange(-8, 8 + 1)
+    if radius <= 8.:
+        L = np.arange(-8., 8. + 1)
         ksize = (3, 3)
     else:
         L = np.arange(-radius, radius + 1)
@@ -979,11 +980,11 @@ def elastic_transform(x: np.ndarray, mult_dxdy: float, sigma: float,
     rnd_rng *= shape[0]
 
     # random affine
-    center_square = np.float32(shape_size) // 2  # type: ignore[arg-type]
+    center_square = np.asarray(shape_size, dtype=np.float32) // 2
     square_size = min(shape_size) // 3
-    pts1 = np.float32([center_square + square_size,
+    pts1 = np.asarray([center_square + square_size,
                        [center_square[0] + square_size, center_square[1] - square_size],
-                       center_square - square_size])  # type: ignore[arg-type]
+                       center_square - square_size], dtype=np.float32)
     pts2 = pts1 + np.random.uniform(-rnd_rng, rnd_rng, size=pts1.shape).astype(np.float32)
     M = cv2.getAffineTransform(pts1, pts2)
     image = cv2.warpAffine(x, M, shape_size[::-1], borderMode=cv2.BORDER_REFLECT_101)

--- a/alibi_detect/utils/pytorch/prediction.py
+++ b/alibi_detect/utils/pytorch/prediction.py
@@ -1,5 +1,5 @@
 from functools import partial
-from typing import Callable, Type, Union, cast
+from typing import Callable, Type, Union
 
 import numpy as np
 import torch

--- a/alibi_detect/utils/pytorch/prediction.py
+++ b/alibi_detect/utils/pytorch/prediction.py
@@ -1,8 +1,9 @@
 from functools import partial
+from typing import Callable, Type, Union, cast
+
 import numpy as np
 import torch
 import torch.nn as nn
-from typing import Callable, Union, Type
 from alibi_detect.utils.prediction import tokenize_transformer
 
 
@@ -64,11 +65,12 @@ def predict_batch(x: Union[list, np.ndarray, torch.Tensor], model: Union[Callabl
             else:
                 raise TypeError(f'Model output type {type(preds_tmp)} not supported. The model output '
                                 f'type needs to be one of list, tuple, np.ndarray or torch.Tensor.')
-    concat = partial(np.concatenate, axis=0) if return_np else partial(torch.cat, dim=0)
-    out = tuple(concat(p) for p in preds) if isinstance(preds, tuple) else concat(preds)
+    concat = partial(np.concatenate, axis=0) if return_np else partial(torch.cat, dim=0)  # type: ignore[arg-type]
+    out = tuple(concat(p) for p in preds) if isinstance(preds, tuple) \
+        else concat(preds)  # type: Union[tuple, np.ndarray, torch.Tensor]
     if return_list:
-        out = list(out)  # TODO: update return type with list
-    return out
+        out = list(out)  # type: ignore[assignment]
+    return out  # TODO: update return type with list
 
 
 def predict_batch_transformer(x: Union[list, np.ndarray], model: Union[nn.Module, nn.Sequential],

--- a/alibi_detect/utils/pytorch/prediction.py
+++ b/alibi_detect/utils/pytorch/prediction.py
@@ -2,13 +2,13 @@ from functools import partial
 import numpy as np
 import torch
 import torch.nn as nn
-from typing import Callable, Union
+from typing import Callable, Union, Type
 from alibi_detect.utils.prediction import tokenize_transformer
 
 
 def predict_batch(x: Union[list, np.ndarray, torch.Tensor], model: Union[Callable, nn.Module, nn.Sequential],
                   device: torch.device = None, batch_size: int = int(1e10), preprocess_fn: Callable = None,
-                  dtype: Union[np.dtype, torch.dtype] = np.float32) -> Union[np.ndarray, torch.Tensor, tuple]:
+                  dtype: Union[Type[np.generic], torch.dtype] = np.float32) -> Union[np.ndarray, torch.Tensor, tuple]:
     """
     Make batch predictions on a model.
 
@@ -67,14 +67,14 @@ def predict_batch(x: Union[list, np.ndarray, torch.Tensor], model: Union[Callabl
     concat = partial(np.concatenate, axis=0) if return_np else partial(torch.cat, dim=0)
     out = tuple(concat(p) for p in preds) if isinstance(preds, tuple) else concat(preds)
     if return_list:
-        out = list(out)
+        out = list(out)  # TODO: update return type with list
     return out
 
 
 def predict_batch_transformer(x: Union[list, np.ndarray], model: Union[nn.Module, nn.Sequential],
                               tokenizer: Callable, max_len: int, device: torch.device = None,
-                              batch_size: int = int(1e10), dtype: Union[np.float32, torch.dtype] = np.float32) \
-        -> Union[np.ndarray, torch.Tensor]:
+                              batch_size: int = int(1e10), dtype: Union[Type[np.generic], torch.dtype] = np.float32) \
+        -> Union[np.ndarray, torch.Tensor, tuple]:
     """
     Make batch predictions using a transformers tokenizer and model.
 

--- a/alibi_detect/utils/tensorflow/data.py
+++ b/alibi_detect/utils/tensorflow/data.py
@@ -7,7 +7,7 @@ Indexable = Union[np.ndarray, tf.Tensor, list]
 
 class TFDataset(tf.keras.utils.Sequence):
     def __init__(
-        self, *indexables: Tuple[Indexable, ...], batch_size: int = int(1e10), shuffle: bool = True,
+            self, *indexables: Indexable, batch_size: int = int(1e10), shuffle: bool = True,
     ) -> None:
         self.indexables = indexables
         self.batch_size = batch_size

--- a/alibi_detect/utils/tensorflow/prediction.py
+++ b/alibi_detect/utils/tensorflow/prediction.py
@@ -1,13 +1,14 @@
 from functools import partial
+from typing import Callable, Type, Union
+
 import numpy as np
 import tensorflow as tf
-from typing import Callable, Union
 from alibi_detect.utils.prediction import tokenize_transformer
 
 
 def predict_batch(x: Union[list, np.ndarray, tf.Tensor], model: Union[Callable, tf.keras.Model],
                   batch_size: int = int(1e10), preprocess_fn: Callable = None,
-                  dtype: Union[np.dtype, tf.DType] = np.float32) -> Union[np.ndarray, tf.Tensor, tuple]:
+                  dtype: Union[Type[np.generic], tf.DType] = np.float32) -> Union[np.ndarray, tf.Tensor, tuple]:
     """
     Make batch predictions on a model.
 
@@ -60,7 +61,7 @@ def predict_batch(x: Union[list, np.ndarray, tf.Tensor], model: Union[Callable, 
 
 def predict_batch_transformer(x: Union[list, np.ndarray], model: tf.keras.Model, tokenizer: Callable,
                               max_len: int, batch_size: int = int(1e10),
-                              dtype: Union[np.float32, tf.DType] = np.float32) \
+                              dtype: Union[Type[np.generic], tf.DType] = np.float32) \
         -> Union[np.ndarray, tf.Tensor]:
     """
     Make batch predictions using a transformers tokenizer and model.

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ exclude =
 [mypy]
 ignore_missing_imports = True
 strict_optional = False
+show_error_codes = True
 
 # sphinx configuration
 [mypy-conf]


### PR DESCRIPTION
This PR is based on the latest `numpy` which has type information. This flags a few issues with our types which have been resolved in this PR. It is a pre-requisite for upgrading to `tensorflow` 2.7.

Most of this PR is pretty straight-forward, however I've left `TODO: TBD` notes where I would welcome a discussion, this is mostly to do with implicit narrowing of types that either `mypy` can't handle (fixed easily with appropriate `type: ignore[code]`) or more seriously with our logic where we haven't considered that a type might not be narrowed down sufficiently (e.g. is the user `list` always an `np.ndarray` by the time it hits a function that only works on `np.ndarray`?).

There will be another PR enabling strict optional typing which will likely reveal a few more issues with current typing.