### PR TITLE
fix docs for learnedkernelldrift

### DIFF
--- a/doc/source/cd/methods/learnedkerneldrift.ipynb
+++ b/doc/source/cd/methods/learnedkerneldrift.ipynb
@@ -55,7 +55,7 @@
     "\n",
     "* `reg_loss_fn`: The regularisation term reg_loss_fn(kernel) is added to the loss function being optimized.\n",
     "\n",
-    "* `train_size`: Optional fraction (float between 0 and 1) of the dataset used to train the classifier. The drift is detected on *1 - train_size*. Cannot be used in combination with `n_folds`.\n",
+    "* `train_size`: Optional fraction (float between 0 and 1) of the dataset used to train the classifier. The drift is detected on *1 - train_size*.\n",
     "\n",
     "* `retrain_from_scratch`: Whether the kernel should be retrained from scratch for each set of test data or whether it should instead continue training from where it left off on the previous set.\n",
     "\n",


### PR DESCRIPTION
This is minor fix.

learnedkernel does not support `n_folds` argument.
https://github.com/SeldonIO/alibi-detect/blob/master/alibi_detect/cd/learned_kernel.py#L16