### PR TITLE
Fix issue with pytorch MMDDrift usage in imdb example

### DIFF
--- a/doc/source/examples/cd_online_camelyon.ipynb
+++ b/doc/source/examples/cd_online_camelyon.ipynb
@@ -18,7 +18,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This notebook requires the `wilds`, `torch` and `torchivision` packages which can be installed via `pip`:"
+    "This notebook requires the `wilds`, `torch` and `torchvision` packages which can be installed via `pip`:"
    ]
   },
   {

--- a/doc/source/examples/cd_online_camelyon.ipynb
+++ b/doc/source/examples/cd_online_camelyon.ipynb
@@ -11,13 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This notebook demonstrates a typical workflow for applying online drift detectors to streams of image data. For those unfamiliar with how the online drift detectors operate in `alibi_detect` we recommend first checking out the more introductory example [Online Drift Detection on the Wine Quality Dataset](https://docs.seldon.io/projects/alibi-detect/en/latest/examples/cd_online_wine.html) where online drift detection is performed for the wine quality dataset.\n",
-    "\n",
-    "Install the `wilds` library to fetch the dataset used in the example:\n",
-    "\n",
-    "```bash\n",
-    "pip install wilds\n",
-    "```"
+    "This notebook demonstrates a typical workflow for applying online drift detectors to streams of image data. For those unfamiliar with how the online drift detectors operate in `alibi_detect` we recommend first checking out the more introductory example [Online Drift Detection on the Wine Quality Dataset](https://docs.seldon.io/projects/alibi-detect/en/latest/examples/cd_online_wine.html) where online drift detection is performed for the wine quality dataset."
    ]
   },
   {

--- a/doc/source/examples/cd_text_imdb.ipynb
+++ b/doc/source/examples/cd_text_imdb.ipynb
@@ -2,7 +2,9 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "zsEdjC-kxfoC"
+   },
    "source": [
     "# Text drift detection on IMDB movie reviews\n",
     "\n",
@@ -15,6 +17,16 @@
     "As a result, we extract (contextual) embeddings for the text and detect drift on those. This procedure has a significant impact on the type of drift we detect. Strictly speaking we are not detecting $\\Delta p(x)$ anymore since the whole training procedure (objective function, training data etc) for the (pre)trained embeddings has an impact on the embeddings we extract.\n",
     "\n",
     "The library contains functionality to leverage pre-trained embeddings from [HuggingFace's transformer package](https://github.com/huggingface/transformers) but also allows you to easily use your own embeddings of choice. Both options are illustrated with examples in this notebook.\n",
+    "\n",
+    "\n",
+    "<div class=\"alert alert-info\">\n",
+    "Note\n",
+    "\n",
+    "As is done in this example, it is recommended to pass text data to detectors as a list of strings (`List[str]`). This allows for seamless integration with HuggingFace's transformers library.\n",
+    "\n",
+    "One exception to the above is when custom embeddings are used. Here, it is important to ensure that the data is passed to the custom embedding model in a compatible format. In [the final example](#Train-embeddings-from-scratch), a `preprocess_batch_fn` is defined in order to convert `list`'s to the `np.ndarray`'s expected by the custom TensorFlow embedding.\n",
+    "    \n",
+    "</div>\n",
     "\n",
     "## Backend\n",
     "\n",
@@ -29,7 +41,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "id": "r6ttO1nVxfoG"
+   },
    "outputs": [],
    "source": [
     "!pip install nlp"
@@ -37,8 +51,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
+   "execution_count": 2,
+   "metadata": {
+    "id": "qG5BL45LxfoG"
+   },
    "outputs": [],
    "source": [
     "import nlp\n",
@@ -52,15 +68,18 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "xhB9-toUxfoH"
+   },
    "source": [
     "### Load tokenizer"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {
+    "id": "ewiBdavQxfoH",
     "scrolled": true
    },
    "outputs": [],
@@ -71,15 +90,19 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "ai9hjQaOxfoI"
+   },
    "source": [
     "### Load data"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
+   "execution_count": 4,
+   "metadata": {
+    "id": "AeINSkzrxfoI"
+   },
    "outputs": [],
    "source": [
     "def load_dataset(dataset: str, split: str = 'test'):\n",
@@ -95,34 +118,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "51MqauScxfoJ",
+    "outputId": "505cc4cf-fe91-4f7d-d009-aff690195f04",
     "scrolled": true
    },
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:nlp.load:Checking /home/avl/.cache/huggingface/datasets/d3b7716978cb901261e59327d43b04c52d6d29e50eeac39bea0816865a584081.7c39fd6270c5ee55bcf2e4de23af77ef299e0df65be3f3e84454dcef7175844a.py for additional imports.\n",
-      "INFO:filelock:Lock 140070637965264 acquired on /home/avl/.cache/huggingface/datasets/d3b7716978cb901261e59327d43b04c52d6d29e50eeac39bea0816865a584081.7c39fd6270c5ee55bcf2e4de23af77ef299e0df65be3f3e84454dcef7175844a.py.lock\n",
-      "INFO:nlp.load:Found main folder for dataset https://s3.amazonaws.com/datasets.huggingface.co/nlp/datasets/imdb/imdb.py at /home/avl/anaconda3/envs/detect/lib/python3.7/site-packages/nlp/datasets/imdb\n",
-      "INFO:nlp.load:Found specific version folder for dataset https://s3.amazonaws.com/datasets.huggingface.co/nlp/datasets/imdb/imdb.py at /home/avl/anaconda3/envs/detect/lib/python3.7/site-packages/nlp/datasets/imdb/76cdbd7249ea3548c928bbf304258dab44d09cd3638d9da8d42480d1d1be3743\n",
-      "INFO:nlp.load:Found script file from https://s3.amazonaws.com/datasets.huggingface.co/nlp/datasets/imdb/imdb.py to /home/avl/anaconda3/envs/detect/lib/python3.7/site-packages/nlp/datasets/imdb/76cdbd7249ea3548c928bbf304258dab44d09cd3638d9da8d42480d1d1be3743/imdb.py\n",
-      "INFO:nlp.load:Found dataset infos file from https://s3.amazonaws.com/datasets.huggingface.co/nlp/datasets/imdb/dataset_infos.json to /home/avl/anaconda3/envs/detect/lib/python3.7/site-packages/nlp/datasets/imdb/76cdbd7249ea3548c928bbf304258dab44d09cd3638d9da8d42480d1d1be3743/dataset_infos.json\n",
-      "INFO:nlp.load:Found metadata file for dataset https://s3.amazonaws.com/datasets.huggingface.co/nlp/datasets/imdb/imdb.py at /home/avl/anaconda3/envs/detect/lib/python3.7/site-packages/nlp/datasets/imdb/76cdbd7249ea3548c928bbf304258dab44d09cd3638d9da8d42480d1d1be3743/imdb.json\n",
-      "INFO:filelock:Lock 140070637965264 released on /home/avl/.cache/huggingface/datasets/d3b7716978cb901261e59327d43b04c52d6d29e50eeac39bea0816865a584081.7c39fd6270c5ee55bcf2e4de23af77ef299e0df65be3f3e84454dcef7175844a.py.lock\n",
-      "INFO:nlp.builder:No config specified, defaulting to first: imdb/plain_text\n",
-      "INFO:nlp.info:Loading Dataset Infos from /home/avl/anaconda3/envs/detect/lib/python3.7/site-packages/nlp/datasets/imdb/76cdbd7249ea3548c928bbf304258dab44d09cd3638d9da8d42480d1d1be3743\n",
-      "INFO:nlp.builder:Overwrite dataset info from restored data version.\n",
-      "INFO:nlp.info:Loading Dataset info from /home/avl/.cache/huggingface/datasets/imdb/plain_text/1.0.0/76cdbd7249ea3548c928bbf304258dab44d09cd3638d9da8d42480d1d1be3743\n",
-      "INFO:nlp.builder:Reusing dataset imdb (/home/avl/.cache/huggingface/datasets/imdb/plain_text/1.0.0/76cdbd7249ea3548c928bbf304258dab44d09cd3638d9da8d42480d1d1be3743)\n",
-      "INFO:nlp.builder:Constructing Dataset for split train, test, unsupervised, from /home/avl/.cache/huggingface/datasets/imdb/plain_text/1.0.0/76cdbd7249ea3548c928bbf304258dab44d09cd3638d9da8d42480d1d1be3743\n",
-      "INFO:nlp.utils.info_utils:All the checksums matched successfully for post processing resources\n",
-      "INFO:nlp.utils.info_utils:All the checksums matched successfully for post processing resources\n",
-      "INFO:nlp.utils.info_utils:All the checksums matched successfully for post processing resources\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -138,15 +143,23 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "MMN3B9k-xfoK"
+   },
    "source": [
     "Let's take a look at respectively a negative and positive review:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
+   "execution_count": 6,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "GwMZIdXzxfoK",
+    "outputId": "fcd16581-0b16-479b-b375-d4bb8122bb64"
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -165,8 +178,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
+   "execution_count": 7,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "TCojQsnCxfoK",
+    "outputId": "66fee3b1-be31-4520-a9d3-f12685d3c9be"
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -184,15 +203,19 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "hjVFuRnKxfoL"
+   },
    "source": [
     "We split the original test set in a reference dataset and a dataset which should not be rejected under the *H0* of the statistical test. We also create imbalanced datasets and inject selected words in the reference set."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
+   "execution_count": 8,
+   "metadata": {
+    "id": "YjV-qwNuxfoL"
+   },
    "outputs": [],
    "source": [
     "def random_sample(X: np.ndarray, y: np.ndarray, proba_zero: float, n: int):\n",
@@ -207,7 +230,7 @@
     "    idx_1_out = np.random.choice(idx_1, n_1, replace=False)\n",
     "    X_out = np.concatenate([X[idx_0_out], X[idx_1_out]])\n",
     "    y_out = np.concatenate([y[idx_0_out], y[idx_1_out]])\n",
-    "    return X_out, y_out\n",
+    "    return X_out.tolist(), y_out.tolist()\n",
     "\n",
     "\n",
     "def padding_last(x: np.ndarray, seq_len: int) -> np.ndarray:\n",
@@ -241,20 +264,24 @@
     "            choice_len = last_token\n",
     "        idx = np.random.choice(np.arange(first_token, choice_len), n_chg, replace=False)\n",
     "        X_cp[_, idx] = token\n",
-    "    return X_cp"
+    "    return X_cp.tolist()"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "YkeJNC6UxfoL"
+   },
    "source": [
     "Reference, *H0* and imbalanced data:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {},
+   "execution_count": 9,
+   "metadata": {
+    "id": "6aZFd5fgxfoL"
+   },
    "outputs": [],
    "source": [
     "# proba_zero = fraction with label 0 (=negative sentiment)\n",
@@ -267,28 +294,20 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "cRyDI1e4xfoM"
+   },
    "source": [
     "Inject words in reference data:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Truncation was not explicitly activated but `max_length` is provided a specific value, please use `truncation=True` to explicitly truncate examples to max length. Defaulting to 'longest_first' truncation strategy. If you encode pairs of sequences (GLUE-style) with the tokenizer you can select this strategy more precisely by providing a specific strategy to `truncation`.\n",
-      "/home/avl/anaconda3/envs/detect/lib/python3.7/site-packages/transformers/tokenization_utils_base.py:2079: FutureWarning:\n",
-      "\n",
-      "The `pad_to_max_length` argument is deprecated and will be removed in a future version, use `padding=True` or `padding='longest'` to pad to the longest sequence in the batch, or use `padding='max_length'` to pad to a max length. In this case, you can give a specific length with `max_length` (e.g. `max_length=45`) or leave max_length to None to pad to the maximal input size of the model (e.g. 512 for Bert).\n",
-      "\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "metadata": {
+    "id": "KCV-JUnnxfoM"
+   },
+   "outputs": [],
    "source": [
     "words = ['fantastic', 'good', 'bad', 'horrible']\n",
     "perc_chg = [1., 5.]  # % of tokens to change in an instance\n",
@@ -296,7 +315,7 @@
     "words_tf = tokenizer(words)['input_ids']\n",
     "words_tf = [token[1:-1][0] for token in words_tf]\n",
     "max_len = 100\n",
-    "tokens = tokenizer(list(X_ref), pad_to_max_length=True, \n",
+    "tokens = tokenizer(X_ref, pad_to_max_length=True, \n",
     "                   max_length=max_len, return_tensors='tf')\n",
     "X_word = {}\n",
     "for i, w in enumerate(words_tf):\n",
@@ -304,12 +323,47 @@
     "    for p in perc_chg:\n",
     "        x = inject_word(w, tokens['input_ids'].numpy(), p)\n",
     "        dec = tokenizer.batch_decode(x, **dict(skip_special_tokens=True))\n",
-    "        X_word[words[i]][p] = np.array(dec)"
+    "        X_word[words[i]][p] = dec"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "nf6SjGzKAPvr",
+    "outputId": "ea0c653b-0d28-4901-f9ca-5e26ff1e23e5"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<tf.Tensor: shape=(1000, 100), dtype=int32, numpy=\n",
+       "array([[  101,  1188,  1794, ...,     0,     0,     0],\n",
+       "       [  101,  1556,  5122, ...,  1307,  1800,   102],\n",
+       "       [  101,  3406,  4720, ...,  5674,  2723,   102],\n",
+       "       ...,\n",
+       "       [  101,  2082,  1122, ...,  1641,   107,   102],\n",
+       "       [  101,  1124,   118, ...,  1155,  1104,   102],\n",
+       "       [  101,  1249, 24017, ...,     0,     0,     0]], dtype=int32)>"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tokens['input_ids']"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "pMJ-JH6WxfoM"
+   },
    "source": [
     "## Preprocessing\n",
     "\n",
@@ -328,23 +382,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {
+    "id": "-kd4nbcXxfoM",
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Some layers from the model checkpoint at bert-base-cased were not used when initializing TFBertModel: ['nsp___cls', 'mlm___cls']\n",
-      "- This IS expected if you are initializing TFBertModel from the checkpoint of a model trained on another task or with another architecture (e.g. initializing a BertForSequenceClassification model from a BertForPreTraining model).\n",
-      "- This IS NOT expected if you are initializing TFBertModel from the checkpoint of a model that you expect to be exactly identical (initializing a BertForSequenceClassification model from a BertForSequenceClassification model).\n",
-      "All the layers of TFBertModel were initialized from the model checkpoint at bert-base-cased.\n",
-      "If your task is similar to the task the model of the checkpoint was trained on, you can already use TFBertModel for predictions without further training.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from alibi_detect.models.tensorflow import TransformerEmbedding\n",
     "\n",
@@ -357,26 +400,21 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "tV3bnMwGxfoM"
+   },
    "source": [
     "Let's check what an embedding looks like:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {
+    "id": "wgJQucxSxfoN",
     "scrolled": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "(5, 768)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "tokens = tokenizer(list(X[:5]), pad_to_max_length=True, \n",
     "                   max_length=max_len, return_tensors='tf')\n",
@@ -386,15 +424,19 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "6IcVvbaYxfoN"
+   },
    "source": [
     "So the BERT model's embedding space used by the drift detector consists of a $768$-dimensional vector for each instance. We will therefore first apply a dimensionality reduction step with an Untrained AutoEncoder (*UAE*) before conducting the statistical hypothesis test. We use the embedding model as the input for the UAE which then projects the embedding on a lower dimensional space."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {},
+   "execution_count": 14,
+   "metadata": {
+    "id": "T6rQpEr5xfoN"
+   },
    "outputs": [],
    "source": [
     "tf.random.set_seed(0)"
@@ -402,8 +444,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {},
+   "execution_count": 15,
+   "metadata": {
+    "id": "yvKnc6ZxxfoN"
+   },
    "outputs": [],
    "source": [
     "from alibi_detect.cd.tensorflow import UAE\n",
@@ -416,15 +460,23 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "mopByQSzxfoN"
+   },
    "source": [
     "Let's test this again:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {},
+   "execution_count": 16,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "aAwVIRRexfoN",
+    "outputId": "9b1ece6b-ce9c-4142-da87-feb9bba97707"
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -441,7 +493,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "Vx73zIu3xfoN"
+   },
    "source": [
     "## K-S detector\n",
     "\n",
@@ -452,89 +506,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {
+    "id": "4OolVqEUxfoN",
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING:alibi_detect.utils.saving:Directory my_path does not exist and is now created.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n",
-      "WARNING:tensorflow:AutoGraph could not transform <bound method Socket.send of <zmq.sugar.socket.Socket object at 0x7f66a01c4280>> and will run it as-is.\n",
-      "Please report this to the TensorFlow team. When filing the bug, set the verbosity to 10 (on Linux, `export AUTOGRAPH_VERBOSITY=10`) and attach the full output.\n",
-      "Cause: module, class, method, function, traceback, frame, or code object was expected, got cython_function_or_method\n",
-      "To silence this warning, decorate the function with @tf.autograph.experimental.do_not_convert\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING:tensorflow:AutoGraph could not transform <bound method Socket.send of <zmq.sugar.socket.Socket object at 0x7f66a01c4280>> and will run it as-is.\n",
-      "Please report this to the TensorFlow team. When filing the bug, set the verbosity to 10 (on Linux, `export AUTOGRAPH_VERBOSITY=10`) and attach the full output.\n",
-      "Cause: module, class, method, function, traceback, frame, or code object was expected, got cython_function_or_method\n",
-      "To silence this warning, decorate the function with @tf.autograph.experimental.do_not_convert\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "WARNING: AutoGraph could not transform <bound method Socket.send of <zmq.sugar.socket.Socket object at 0x7f66a01c4280>> and will run it as-is.\n",
-      "Please report this to the TensorFlow team. When filing the bug, set the verbosity to 10 (on Linux, `export AUTOGRAPH_VERBOSITY=10`) and attach the full output.\n",
-      "Cause: module, class, method, function, traceback, frame, or code object was expected, got cython_function_or_method\n",
-      "To silence this warning, decorate the function with @tf.autograph.experimental.do_not_convert\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n",
-      "All model checkpoint layers were used when initializing TFBertModel.\n",
-      "\n",
-      "All the layers of TFBertModel were initialized from the model checkpoint at my_path/model.\n",
-      "If your task is similar to the task the model of the checkpoint was trained on, you can already use TFBertModel for predictions without further training.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "WARNING:tensorflow:No training configuration found in the save file, so the model was *not* compiled. Compile it manually.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING:tensorflow:No training configuration found in the save file, so the model was *not* compiled. Compile it manually.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from functools import partial\n",
     "from alibi_detect.cd.tensorflow import preprocess_drift\n",
@@ -554,7 +531,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "lpZbGa-2xfoO"
+   },
    "source": [
     "### Detect drift\n",
     "\n",
@@ -563,27 +542,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Truncation was not explicitly activated but `max_length` is provided a specific value, please use `truncation=True` to explicitly truncate examples to max length. Defaulting to 'longest_first' truncation strategy. If you encode pairs of sequences (GLUE-style) with the tokenizer you can select this strategy more precisely by providing a specific strategy to `truncation`.\n"
-     ]
+   "execution_count": 18,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
     },
+    "id": "E1E56gnvxfoO",
+    "outputId": "af5dedcf-9be2-4c9c-8c4c-b44196af7d42"
+   },
+   "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "Drift? No!\n",
-      "p-value: [0.85929435 0.46576622 0.79439443 0.82795686 0.722555   0.7590978\n",
-      " 0.46576622 0.82795686 0.02246371 0.21933001 0.6852314  0.8879386\n",
-      " 0.5726548  0.5726548  0.50035924 0.9801618  0.9540582  0.3699725\n",
-      " 0.82795686 0.07762147 0.7590978  0.9134755  0.9540582  0.40047103\n",
-      " 0.06155144 0.28769323 0.5726548  0.64755726 0.5726548  0.2406036\n",
-      " 0.722555   0.00282894]\n"
+      "p-value: [0.31356168 0.18111965 0.60991895 0.43243074 0.6852314  0.722555\n",
+      " 0.28769323 0.18111965 0.50035924 0.9134755  0.40047103 0.79439443\n",
+      " 0.79439443 0.722555   0.5726548  0.1640792  0.9540582  0.60991895\n",
+      " 0.5726548  0.5726548  0.31356168 0.40047103 0.6852314  0.34099194\n",
+      " 0.5726548  0.07762147 0.79439443 0.09710453 0.5726548  0.79439443\n",
+      " 0.7590978  0.26338065]\n"
      ]
     }
    ],
@@ -596,15 +574,23 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "Q1Ub4WpYxfoO"
+   },
    "source": [
     "Detect drift on imbalanced and perturbed datasets:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {},
+   "execution_count": 19,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "2_8Dw8QBxfoO",
+    "outputId": "c765e7f1-0ff3-43c9-d674-c573d137ec56"
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -612,24 +598,25 @@
      "text": [
       "% negative sentiment 10.0\n",
       "Drift? Yes!\n",
-      "p-value: [4.32430744e-01 7.22554982e-01 6.85231388e-01 6.09918952e-01\n",
-      " 1.81119651e-01 6.20218972e-03 1.22740539e-03 1.12110768e-02\n",
-      " 1.63965786e-04 3.69972497e-01 5.36054313e-01 8.59294355e-01\n",
-      " 8.27956855e-01 1.81119651e-01 4.00471032e-01 6.47557259e-01\n",
-      " 7.76214674e-02 1.20504074e-01 1.33834302e-01 2.24637091e-02\n",
-      " 6.47557259e-01 8.69054198e-02 7.76214674e-02 7.94394433e-01\n",
-      " 1.20504074e-01 3.40991944e-01 5.72654784e-01 2.87693232e-01\n",
-      " 2.87693232e-01 5.72654784e-01 1.99518353e-01 2.87693232e-01]\n",
+      "p-value: [4.32430744e-01 4.00471032e-01 5.46463318e-02 7.76214674e-02\n",
+      " 1.08282514e-01 1.12110768e-02 6.91903234e-02 2.82894098e-03\n",
+      " 8.59294355e-01 6.47557259e-01 1.33834302e-01 7.94394433e-01\n",
+      " 4.28151786e-02 2.87693232e-01 6.09918952e-01 1.33834302e-01\n",
+      " 2.40603596e-01 9.71045271e-02 7.76214674e-02 9.35580969e-01\n",
+      " 2.87693232e-01 2.92505771e-02 4.00471032e-01 6.09918952e-01\n",
+      " 2.87693232e-01 5.06567594e-04 1.64079204e-01 6.09918952e-01\n",
+      " 1.33834302e-01 2.19330013e-01 7.94394433e-01 2.56591532e-02]\n",
       "\n",
       "% negative sentiment 90.0\n",
       "Drift? Yes!\n",
-      "p-value: [5.9607941e-01 3.1773445e-01 1.0167704e-01 6.0131598e-01 4.7765803e-03\n",
-      " 7.8468665e-02 5.4378760e-01 3.1890289e-04 4.7273561e-02 2.3027392e-01\n",
-      " 3.5409841e-01 2.2440368e-01 4.5503160e-01 8.8078308e-01 7.5261140e-01\n",
-      " 6.5092611e-01 3.8073459e-01 5.4552953e-04 6.6255075e-01 6.9101667e-01\n",
-      " 3.9483134e-02 8.2559012e-02 3.2168049e-01 1.9095013e-01 7.0450002e-01\n",
-      " 1.5517529e-06 9.7765464e-01 9.8889194e-02 6.3466263e-01 2.9970827e-02\n",
-      " 1.7626658e-01 5.0656848e-02]\n",
+      "p-value: [7.36993998e-02 1.37563676e-01 5.86588383e-02 5.07961273e-01\n",
+      " 8.37696046e-02 8.80799629e-03 1.23670578e-01 1.76981179e-04\n",
+      " 3.21924835e-01 1.20594716e-02 8.43600273e-01 4.08206195e-01\n",
+      " 1.69703156e-01 5.79056978e-01 6.32701874e-01 4.48510349e-02\n",
+      " 5.07465303e-01 6.64306164e-04 5.23085408e-02 3.78374875e-01\n",
+      " 6.65342569e-01 4.06090707e-01 6.21288121e-01 5.85612692e-02\n",
+      " 5.87646782e-01 7.55570829e-03 8.99188042e-01 1.18489005e-02\n",
+      " 6.68586135e-01 1.01421457e-02 7.97733963e-02 1.73885196e-01]\n",
       "\n"
      ]
     }
@@ -645,8 +632,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 20,
    "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "K7GYX5_BxfoO",
+    "outputId": "98d4a86a-e741-4709-a95e-a72e45d95cc8",
     "scrolled": false
    },
    "outputs": [
@@ -656,83 +648,85 @@
      "text": [
       "Word: fantastic -- % perturbed: 1.0\n",
       "Drift? No!\n",
-      "p-value: [0.9540582  0.01293455 0.26338065 0.722555   0.34099194 0.04281518\n",
-      " 0.04841881 0.31356168 0.14833806 0.96887016 0.85929435 0.50035924\n",
-      " 0.00532228 0.8879386  0.9998709  0.99870795 0.85929435 0.9882611\n",
-      " 0.06155144 0.7590978  0.79439443 0.2406036  0.10828251 0.722555\n",
-      " 0.28769323 0.18111965 0.9134755  0.996931   0.18111965 0.07762147\n",
-      " 0.9540582  0.5726548 ]\n",
+      "p-value: [0.8879386  0.01711409 0.2406036  0.9134755  0.21933001 0.04281518\n",
+      " 0.03778438 0.28769323 0.3699725  0.996931   0.8879386  0.43243074\n",
+      " 0.01121108 0.6852314  0.99870795 0.996931   0.93558097 0.99365413\n",
+      " 0.02246371 0.60991895 0.8879386  0.34099194 0.09710453 0.8879386\n",
+      " 0.1338343  0.06155144 0.85929435 0.99365413 0.07762147 0.07762147\n",
+      " 0.9882611  0.85929435]\n",
       "\n",
       "Word: fantastic -- % perturbed: 5.0\n",
       "Drift? Yes!\n",
-      "p-value: [4.55808453e-03 4.14164800e-17 2.43227714e-08 6.85231388e-01\n",
-      " 3.18301190e-08 1.26629300e-17 1.10562748e-09 1.71140861e-02\n",
-      " 1.69780876e-14 3.50604125e-04 1.48931602e-02 1.84965307e-10\n",
-      " 0.00000000e+00 1.48931602e-02 9.93654132e-01 1.08282514e-01\n",
-      " 3.40991944e-01 2.19330013e-01 2.14098059e-19 7.76214674e-02\n",
-      " 3.25786677e-05 1.69780876e-14 1.09291570e-20 6.15514442e-02\n",
-      " 8.36122004e-23 4.56308130e-10 1.20504074e-01 4.00471032e-01\n",
-      " 2.86754206e-33 7.08821891e-21 2.26972293e-06 7.42663324e-05]\n",
+      "p-value: [1.29345525e-02 1.69780876e-14 1.52437299e-11 5.72654784e-01\n",
+      " 1.85489473e-08 1.88342838e-17 6.14975981e-09 4.28151786e-02\n",
+      " 5.62237052e-13 2.13202584e-05 4.28151786e-02 1.97469308e-09\n",
+      " 0.00000000e+00 1.48931602e-02 9.68870163e-01 1.29345525e-02\n",
+      " 2.63380647e-01 1.08282514e-01 1.04535818e-26 4.28151786e-02\n",
+      " 2.13202584e-05 3.47411038e-14 1.09291570e-20 1.08282514e-01\n",
+      " 5.68982140e-18 1.69780876e-14 1.64079204e-01 4.00471032e-01\n",
+      " 3.12689441e-34 3.89208371e-27 2.86525619e-06 1.71956726e-05]\n",
       "\n",
       "Word: good -- % perturbed: 1.0\n",
       "Drift? Yes!\n",
-      "p-value: [2.1933001e-01 9.1347551e-01 1.3383430e-01 9.9954331e-01 2.6338065e-01\n",
-      " 9.9954331e-01 6.0991895e-01 8.8793862e-01 9.6887016e-01 5.7265478e-01\n",
-      " 9.3558097e-01 5.3605431e-01 9.7104527e-02 9.9870795e-01 9.3558097e-01\n",
-      " 4.6576622e-01 9.9987090e-01 2.6338065e-01 9.9693102e-01 1.1211077e-02\n",
-      " 9.3558097e-01 9.1347551e-01 6.0991895e-01 7.2255498e-01 6.0991895e-01\n",
-      " 9.9870795e-01 9.6887016e-01 9.9870795e-01 5.7265478e-01 4.2185336e-04\n",
-      " 9.9365413e-01 9.8016179e-01]\n",
+      "p-value: [3.40991944e-01 9.80161786e-01 1.08282514e-01 9.98707950e-01\n",
+      " 1.48338065e-01 9.35580969e-01 7.59097815e-01 9.88261104e-01\n",
+      " 8.87938619e-01 6.47557259e-01 9.68870163e-01 7.94394433e-01\n",
+      " 8.69054198e-02 9.99999642e-01 9.96931016e-01 5.72654784e-01\n",
+      " 9.99870896e-01 4.32430744e-01 9.99870896e-01 2.92505771e-02\n",
+      " 9.13475513e-01 9.13475513e-01 4.65766221e-01 9.35580969e-01\n",
+      " 8.87938619e-01 9.98707950e-01 9.80161786e-01 9.99972701e-01\n",
+      " 7.59097815e-01 1.34916729e-04 9.96931016e-01 9.68870163e-01]\n",
       "\n",
       "Word: good -- % perturbed: 5.0\n",
       "Drift? Yes!\n",
-      "p-value: [2.86769516e-16 9.98707950e-01 4.91978077e-19 7.94394433e-01\n",
-      " 4.64324268e-09 7.22554982e-01 3.50604125e-04 3.40991944e-01\n",
-      " 1.34916729e-04 2.09715821e-11 6.47557259e-01 4.21853358e-04\n",
-      " 1.65277426e-33 5.46463318e-02 3.40991944e-01 1.84965307e-10\n",
-      " 5.36054313e-01 1.00300261e-10 9.80161786e-01 1.69780876e-14\n",
-      " 9.13475513e-01 3.27475419e-07 2.54783203e-07 3.32311448e-03\n",
-      " 1.34916729e-04 1.20504074e-01 6.15514442e-02 7.94394433e-01\n",
-      " 1.18559271e-07 0.00000000e+00 2.82894098e-03 1.64079204e-01]\n",
+      "p-value: [6.1319246e-16 8.5929435e-01 8.4248814e-24 5.3605431e-01 6.1410643e-10\n",
+      " 1.9951835e-01 2.9080641e-04 3.6997250e-01 2.4072561e-04 3.3837957e-10\n",
+      " 9.5405817e-01 8.6666952e-04 5.2673625e-28 1.4893160e-02 9.7104527e-02\n",
+      " 5.3955968e-11 1.6407920e-01 6.1410643e-10 7.2255498e-01 2.5362303e-18\n",
+      " 7.9439443e-01 1.7943768e-06 1.5330249e-07 2.0378644e-03 1.4563050e-03\n",
+      " 2.1933001e-01 1.9626908e-02 6.4755726e-01 1.4790693e-09 0.0000000e+00\n",
+      " 1.9626908e-02 3.1356168e-01]\n",
       "\n",
       "Word: bad -- % perturbed: 1.0\n",
       "Drift? No!\n",
-      "p-value: [0.6852314  0.40047103 0.1338343  0.9882611  0.50035924 0.9882611\n",
-      " 0.9999727  0.8879386  0.8879386  0.46576622 0.8879386  0.85929435\n",
-      " 0.01962691 0.9540582  0.9998709  0.40047103 0.21933001 0.01962691\n",
-      " 0.6852314  0.18111965 0.31356168 0.6852314  0.14833806 0.9134755\n",
-      " 0.93558097 0.99870795 0.9999727  0.99365413 0.722555   0.21933001\n",
-      " 0.06155144 0.9998709 ]\n",
+      "p-value: [0.8879386  0.21933001 0.12050407 0.9540582  0.9134755  0.9540582\n",
+      " 0.99870795 0.9540582  0.7590978  0.40047103 0.9801618  0.7590978\n",
+      " 0.02925058 0.996931   0.9995433  0.79439443 0.26338065 0.04281518\n",
+      " 0.93558097 0.14833806 0.50035924 0.82795686 0.18111965 0.43243074\n",
+      " 0.99365413 0.9882611  0.9801618  0.99870795 0.96887016 0.10828251\n",
+      " 0.07762147 0.9882611 ]\n",
       "\n",
       "Word: bad -- % perturbed: 5.0\n",
       "Drift? Yes!\n",
-      "p-value: [8.2482254e-10 2.8794037e-11 8.4967083e-18 2.4060360e-01 3.2578668e-05\n",
-      " 2.4060360e-01 5.7265478e-01 1.4833806e-01 3.6098195e-06 1.3007273e-15\n",
-      " 3.1356168e-01 4.1571425e-08 1.0593816e-42 7.2607823e-04 2.4060360e-01\n",
-      " 1.7114086e-02 1.8548947e-08 4.5879536e-21 1.8111965e-01 1.9783097e-07\n",
-      " 8.4248814e-24 4.6432427e-09 2.8676952e-16 7.2131259e-03 4.3243074e-01\n",
-      " 9.1347551e-01 1.6407920e-01 1.4563050e-03 5.3955968e-11 6.1319246e-16\n",
-      " 4.9197808e-19 9.8016179e-01]\n",
+      "p-value: [7.04859247e-08 5.78442112e-12 7.08821891e-21 1.33834302e-01\n",
+      " 7.13247118e-06 3.69972497e-01 9.68870163e-01 1.81119651e-01\n",
+      " 2.13202584e-05 3.47411038e-14 5.00359237e-01 1.97830971e-07\n",
+      " 9.82534992e-39 1.03241683e-03 1.96269080e-02 2.92505771e-02\n",
+      " 8.76041099e-07 8.49670826e-18 1.08282514e-01 3.38379574e-10\n",
+      " 8.07501343e-25 5.37760343e-07 2.79573150e-17 2.40344345e-03\n",
+      " 1.99518353e-01 7.59097815e-01 8.69054198e-02 3.32311448e-03\n",
+      " 2.15581372e-12 3.95873130e-15 1.95523170e-16 5.72654784e-01]\n",
       "\n",
       "Word: horrible -- % perturbed: 1.0\n",
       "Drift? Yes!\n",
-      "p-value: [0.26338065 0.9995433  0.99870795 0.9540582  0.7590978  0.722555\n",
-      " 0.9999727  0.9134755  0.00145631 0.99870795 0.9995433  0.64755726\n",
-      " 0.09710453 0.99870795 0.5360543  0.99870795 0.04281518 0.1338343\n",
-      " 0.82795686 0.1338343  0.1640792  0.9134755  0.43243074 0.9801618\n",
-      " 0.9995433  0.1338343  0.99365413 0.9999727  0.9998709  0.00203786\n",
-      " 0.1640792  0.7590978 ]\n",
+      "p-value: [2.63380647e-01 9.98707950e-01 9.98707950e-01 9.88261104e-01\n",
+      " 6.47557259e-01 8.59294355e-01 9.96931016e-01 9.13475513e-01\n",
+      " 3.50604125e-04 9.99870896e-01 9.99870896e-01 6.09918952e-01\n",
+      " 1.33834302e-01 9.80161786e-01 9.35580969e-01 9.88261104e-01\n",
+      " 9.71045271e-02 4.00471032e-01 6.85231388e-01 1.81119651e-01\n",
+      " 4.65766221e-01 9.80161786e-01 8.69054198e-02 9.96931016e-01\n",
+      " 9.99870896e-01 6.91903234e-02 9.80161786e-01 9.99972701e-01\n",
+      " 9.93654132e-01 5.32228360e-03 1.20504074e-01 7.22554982e-01]\n",
       "\n",
       "Word: horrible -- % perturbed: 5.0\n",
       "Drift? Yes!\n",
-      "p-value: [1.26629300e-17 5.36054313e-01 1.20504074e-01 8.27956855e-01\n",
-      " 7.26078229e-04 9.69783217e-03 4.84188050e-02 6.07078255e-04\n",
-      " 3.21035236e-38 4.01514189e-05 2.87693232e-01 1.84965307e-10\n",
-      " 5.41929480e-39 1.64079204e-01 1.63965786e-04 1.48338065e-01\n",
-      " 1.41174699e-08 1.98871276e-04 4.56308130e-10 1.95523170e-16\n",
-      " 6.34892210e-31 2.54783203e-07 9.03489017e-17 9.80161786e-01\n",
-      " 4.15714254e-08 4.95470906e-14 9.13475513e-01 1.98871276e-04\n",
-      " 5.62237052e-13 0.00000000e+00 2.79573150e-17 1.71140861e-02]\n",
+      "p-value: [1.6978088e-14 8.8793862e-01 2.8769323e-01 5.7265478e-01 1.3491673e-04\n",
+      " 1.7114086e-02 4.3243074e-01 1.1211077e-02 8.5801831e-33 3.5060412e-04\n",
+      " 8.6905420e-02 6.1497598e-09 1.4797455e-32 1.3383430e-01 1.7244401e-03\n",
+      " 2.6338065e-01 1.4117470e-08 3.5060412e-04 5.7140245e-15 4.9547091e-14\n",
+      " 5.9822431e-37 8.9143086e-06 8.4967083e-18 3.1356168e-01 8.7604110e-07\n",
+      " 3.9584363e-20 1.4833806e-01 1.7244401e-03 1.1053569e-12 0.0000000e+00\n",
+      " 1.3007273e-15 2.9250577e-02]\n",
       "\n"
      ]
     }
@@ -749,7 +743,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "nWwYweooxfoO"
+   },
    "source": [
     "## MMD TensorFlow detector\n",
     "\n",
@@ -760,8 +756,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {},
+   "execution_count": 21,
+   "metadata": {
+    "id": "APKk7FO3xfoO"
+   },
    "outputs": [],
    "source": [
     "cd = MMDDrift(X_ref, p_val=.05, preprocess_fn=preprocess_fn, \n",
@@ -770,7 +768,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "hm8DtTsnxfoP"
+   },
    "source": [
     "### Detect drift\n",
     "\n",
@@ -779,15 +779,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
-   "metadata": {},
+   "execution_count": 22,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "jskCFE1QxfoP",
+    "outputId": "5ce043b0-9fdf-4634-cbe4-a041651e5124"
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "Drift? No!\n",
-      "p-value: 0.9\n"
+      "p-value: 0.6\n"
      ]
     }
    ],
@@ -800,15 +806,23 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "5IaVVZJ8xfoP"
+   },
    "source": [
     "Imbalanced data:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
-   "metadata": {},
+   "execution_count": 23,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "ukf96vjWxfoP",
+    "outputId": "2393abdc-c043-45e2-e3f7-16eafa64deb0"
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -816,7 +830,7 @@
      "text": [
       "% negative sentiment 10.0\n",
       "Drift? Yes!\n",
-      "p-value: 0.0\n",
+      "p-value: 0.01\n",
       "\n",
       "% negative sentiment 90.0\n",
       "Drift? Yes!\n",
@@ -836,15 +850,22 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "1utu6w7oxfoP"
+   },
    "source": [
     "Perturbed data:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 24,
    "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "sP9amuYBxfoP",
+    "outputId": "9cab23b5-522f-4942-91a6-177bffde0729",
     "scrolled": false
    },
    "outputs": [
@@ -853,8 +874,8 @@
      "output_type": "stream",
      "text": [
       "Word: fantastic -- % perturbed: 1.0\n",
-      "Drift? Yes!\n",
-      "p-value: 0.01\n",
+      "Drift? No!\n",
+      "p-value: 0.09\n",
       "\n",
       "Word: fantastic -- % perturbed: 5.0\n",
       "Drift? Yes!\n",
@@ -862,7 +883,7 @@
       "\n",
       "Word: good -- % perturbed: 1.0\n",
       "Drift? No!\n",
-      "p-value: 0.57\n",
+      "p-value: 0.71\n",
       "\n",
       "Word: good -- % perturbed: 5.0\n",
       "Drift? Yes!\n",
@@ -870,7 +891,7 @@
       "\n",
       "Word: bad -- % perturbed: 1.0\n",
       "Drift? No!\n",
-      "p-value: 0.4\n",
+      "p-value: 0.38\n",
       "\n",
       "Word: bad -- % perturbed: 5.0\n",
       "Drift? Yes!\n",
@@ -878,7 +899,7 @@
       "\n",
       "Word: horrible -- % perturbed: 1.0\n",
       "Drift? No!\n",
-      "p-value: 0.08\n",
+      "p-value: 0.18\n",
       "\n",
       "Word: horrible -- % perturbed: 5.0\n",
       "Drift? Yes!\n",
@@ -899,7 +920,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "4CjTZKNKxfoP"
+   },
    "source": [
     "## MMD PyTorch detector\n",
     "\n",
@@ -910,8 +933,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
-   "metadata": {},
+   "execution_count": 25,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "oUdfEom7xfoP",
+    "outputId": "66e60675-7a96-491b-e085-6e6a897c5d91"
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -936,40 +965,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {
+    "id": "K0ha7VawxfoP",
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:filelock:Lock 140068554309968 acquired on /home/avl/.cache/huggingface/transformers/092cc582560fc3833e556b3f833695c26343cb54b7e88cd02d40821462a74999.1f48cab6c959fc6c360d22bea39d06959e90f5b002e77e836d2da45464875cda.lock\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b4e0dbd5f25f4032a36bdbfb12d547f1",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Downloading:   0%|          | 0.00/436M [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:filelock:Lock 140068554309968 released on /home/avl/.cache/huggingface/transformers/092cc582560fc3833e556b3f833695c26343cb54b7e88cd02d40821462a74999.1f48cab6c959fc6c360d22bea39d06959e90f5b002e77e836d2da45464875cda.lock\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from alibi_detect.cd.pytorch import preprocess_drift\n",
     "from alibi_detect.models.pytorch import TransformerEmbedding\n",
@@ -985,7 +986,7 @@
     "\n",
     "# define preprocessing function\n",
     "preprocess_fn = partial(preprocess_drift, model=model, tokenizer=tokenizer, \n",
-    "                        max_len=max_len, batch_size=32)\n",
+    "                        max_len=max_len, batch_size=32, device=device)\n",
     "\n",
     "# initialise drift detector\n",
     "cd = MMDDrift(X_ref, backend='pytorch', p_val=.05, preprocess_fn=preprocess_fn, \n",
@@ -994,7 +995,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "Q9D2TeJRxfoQ"
+   },
    "source": [
     "### Detect drift\n",
     "\n",
@@ -1003,15 +1006,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
-   "metadata": {},
+   "execution_count": 27,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "kieWKHL4xfoQ",
+    "outputId": "f7d47763-6c02-4fee-f750-b5548a736410"
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "Drift? No!\n",
-      "p-value: 0.3400000035762787\n"
+      "p-value: 0.49000000953674316\n"
      ]
     }
    ],
@@ -1024,15 +1033,23 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "DZ_pUMKRxfoQ"
+   },
    "source": [
     "Imbalanced data:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
-   "metadata": {},
+   "execution_count": 28,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "ZznEh7WSxfoQ",
+    "outputId": "13cf9b46-a17b-4fd6-a26c-cefad396d262"
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1060,23 +1077,31 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "s-zKhsRexfoQ"
+   },
    "source": [
     "Perturbed data:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
-   "metadata": {},
+   "execution_count": 29,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "tqccOJCSxfoQ",
+    "outputId": "77edb585-c88e-4293-ee7a-76daee888c6a"
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "Word: fantastic -- % perturbed: 1.0\n",
-      "Drift? No!\n",
-      "p-value: 0.07999999821186066\n",
+      "Drift? Yes!\n",
+      "p-value: 0.0\n",
       "\n",
       "Word: fantastic -- % perturbed: 5.0\n",
       "Drift? Yes!\n",
@@ -1084,15 +1109,15 @@
       "\n",
       "Word: good -- % perturbed: 1.0\n",
       "Drift? No!\n",
-      "p-value: 0.7099999785423279\n",
+      "p-value: 0.10000000149011612\n",
       "\n",
       "Word: good -- % perturbed: 5.0\n",
       "Drift? Yes!\n",
       "p-value: 0.0\n",
       "\n",
       "Word: bad -- % perturbed: 1.0\n",
-      "Drift? No!\n",
-      "p-value: 0.12999999523162842\n",
+      "Drift? Yes!\n",
+      "p-value: 0.0\n",
       "\n",
       "Word: bad -- % perturbed: 5.0\n",
       "Drift? Yes!\n",
@@ -1100,7 +1125,7 @@
       "\n",
       "Word: horrible -- % perturbed: 1.0\n",
       "Drift? No!\n",
-      "p-value: 0.33000001311302185\n",
+      "p-value: 0.05999999865889549\n",
       "\n",
       "Word: horrible -- % perturbed: 5.0\n",
       "Drift? Yes!\n",
@@ -1121,7 +1146,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "BBNO_KDKxfoQ"
+   },
    "source": [
     "## Train embeddings from scratch\n",
     "\n",
@@ -1132,8 +1159,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
-   "metadata": {},
+   "execution_count": 30,
+   "metadata": {
+    "id": "V1r8BuPBxfoQ"
+   },
    "outputs": [],
    "source": [
     "from tensorflow.keras.datasets import imdb, reuters\n",
@@ -1183,6 +1212,7 @@
     "\n",
     "def imdb_model(X: np.ndarray, num_words: int = 100, emb_dim: int = 128,\n",
     "               lstm_dim: int = 128, output_dim: int = 2) -> tf.keras.Model:\n",
+    "    X = np.array(X)\n",
     "    inputs = Input(shape=(X.shape[1:]), dtype=tf.float32)\n",
     "    x = Embedding(num_words, emb_dim)(inputs)\n",
     "    x = LSTM(lstm_dim, dropout=.5)(x)\n",
@@ -1198,37 +1228,21 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "mm4Xlq8axfoQ"
+   },
    "source": [
     "Load and tokenize data:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 31,
    "metadata": {
+    "id": "hKQGbwt-xfoR",
     "scrolled": false
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "<string>:6: VisibleDeprecationWarning:\n",
-      "\n",
-      "Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray\n",
-      "\n",
-      "/home/avl/anaconda3/envs/detect/lib/python3.7/site-packages/tensorflow/python/keras/datasets/imdb.py:159: VisibleDeprecationWarning:\n",
-      "\n",
-      "Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray\n",
-      "\n",
-      "/home/avl/anaconda3/envs/detect/lib/python3.7/site-packages/tensorflow/python/keras/datasets/imdb.py:160: VisibleDeprecationWarning:\n",
-      "\n",
-      "Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "(X_train, y_train), (X_test, y_test), (word2token, token2word) = \\\n",
     "    get_dataset(dataset='imdb', max_len=max_len)"
@@ -1236,15 +1250,23 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "vYMCcVqIxfoR"
+   },
    "source": [
     "Let's check out an instance:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
-   "metadata": {},
+   "execution_count": 32,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "BcbldijMxfoR",
+    "outputId": "8a0864e3-ab47-48b8-b161-5c0c7a5d6fba"
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1269,33 +1291,41 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "Y381SpEdxfoR"
+   },
    "source": [
     "Define and train a simple model:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
-   "metadata": {},
+   "execution_count": 33,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "Qec5Rv9axfoR",
+    "outputId": "26b29ea3-4224-4da9-9383-341486417262"
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "Epoch 1/2\n",
-      "782/782 [==============================] - 96s 121ms/step - loss: 0.5019 - accuracy: 0.7397 - val_loss: 0.3452 - val_accuracy: 0.8514\n",
+      "782/782 [==============================] - 17s 17ms/step - loss: 0.4314 - accuracy: 0.7988 - val_loss: 0.3481 - val_accuracy: 0.8474\n",
       "Epoch 2/2\n",
-      "782/782 [==============================] - 93s 118ms/step - loss: 0.2649 - accuracy: 0.8943 - val_loss: 0.3628 - val_accuracy: 0.8454\n"
+      "782/782 [==============================] - 14s 18ms/step - loss: 0.2707 - accuracy: 0.8908 - val_loss: 0.3858 - val_accuracy: 0.8451\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "<tensorflow.python.keras.callbacks.History at 0x7f6440301310>"
+       "<keras.callbacks.History at 0x7fb07edfef50>"
       ]
      },
-     "execution_count": 31,
+     "execution_count": 33,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1308,15 +1338,23 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "8XXdfhN_xfoR"
+   },
    "source": [
     "Extract the embedding layer from the trained model and combine with UAE preprocessing step:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
-   "metadata": {},
+   "execution_count": 34,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "RhkU0K8OxfoR",
+    "outputId": "f03ec951-d108-48d4-de6e-a603d9d44a10"
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1334,8 +1372,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
-   "metadata": {},
+   "execution_count": 35,
+   "metadata": {
+    "id": "c6oZYWLNxfoR"
+   },
    "outputs": [],
    "source": [
     "tf.random.set_seed(0)\n",
@@ -1346,15 +1386,19 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "_9dv3scexfoR"
+   },
    "source": [
     "Again, create reference, *H0* and perturbed datasets. Also test against the *Reuters* news topic classification dataset."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
-   "metadata": {},
+   "execution_count": 36,
+   "metadata": {
+    "id": "6QuvJjxxxfoR"
+   },
    "outputs": [],
    "source": [
     "X_ref, y_ref = random_sample(X_test, y_test, proba_zero=.5, n=n_sample)\n",
@@ -1364,31 +1408,17 @@
     "for i, t in enumerate(tokens):\n",
     "    X_word[words[i]] = {}\n",
     "    for p in perc_chg:\n",
-    "        X_word[words[i]][p] = inject_word(t, X_ref, p, padding='first')"
+    "        X_word[words[i]][p] = inject_word(t, np.array(X_ref), p, padding='first')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 37,
    "metadata": {
+    "id": "DnZ45KNLxfoS",
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/avl/anaconda3/envs/detect/lib/python3.7/site-packages/tensorflow/python/keras/datasets/reuters.py:148: VisibleDeprecationWarning:\n",
-      "\n",
-      "Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray\n",
-      "\n",
-      "/home/avl/anaconda3/envs/detect/lib/python3.7/site-packages/tensorflow/python/keras/datasets/reuters.py:149: VisibleDeprecationWarning:\n",
-      "\n",
-      "Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# load and tokenize Reuters dataset\n",
     "(X_reut, y_reut), (w2t_reut, t2w_reut) = \\\n",
@@ -1401,21 +1431,41 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "LGW7I9DWxfoS"
+   },
    "source": [
     "### Initialize detector and detect drift"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 38,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "EuWYGUAbxfoS",
+    "outputId": "bb070dc7-c9b4-4b5c-8d80-36c8a7867577"
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Input shape could not be inferred. If alibi_detect.models.tensorflow.embedding.TransformerEmbedding is used as preprocessing step, a saved detector cannot be reinitialized.\n"
+     ]
+    }
+   ],
    "source": [
     "from alibi_detect.cd.tensorflow import preprocess_drift\n",
     "\n",
+    "# define preprocess_batch_fn to convert list of str's to np.ndarray to be processed by `model`\n",
+    "def convert_list(X: list):\n",
+    "    return np.array(X)\n",
+    "\n",
     "# define preprocessing function\n",
-    "preprocess_fn = partial(preprocess_drift, model=uae, batch_size=128)\n",
+    "preprocess_fn = partial(preprocess_drift, model=uae, batch_size=128, preprocess_batch_fn=convert_list)\n",
     "\n",
     "# initialize detector\n",
     "cd = KSDrift(X_ref, p_val=.05, preprocess_fn=preprocess_fn)"
@@ -1423,32 +1473,40 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "VzdN0DN6xfoS"
+   },
    "source": [
     "*H0*:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
-   "metadata": {},
+   "execution_count": 39,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "ZxPNEB1FxfoS",
+    "outputId": "fbd11ff2-d91b-4633-877c-c669abef3c93"
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "Drift? No!\n",
-      "p-value: [0.93558097 0.64755726 0.50035924 0.85929435 0.04281518 0.93558097\n",
-      " 0.9801618  0.50035924 0.8879386  0.43243074 0.5726548  0.6852314\n",
-      " 0.60991895 0.9134755  0.18111965 0.722555   0.5726548  0.21933001\n",
-      " 0.5360543  0.6852314  0.85929435 0.31356168 0.9801618  0.18111965\n",
-      " 0.34099194 0.722555   0.04841881 0.99365413 0.82795686 0.14833806\n",
-      " 0.1338343  0.9134755 ]\n"
+      "p-value: [0.18111965 0.50035924 0.5360543  0.722555   0.2406036  0.02925058\n",
+      " 0.43243074 0.12050407 0.722555   0.60991895 0.19951835 0.60991895\n",
+      " 0.50035924 0.79439443 0.722555   0.64755726 0.40047103 0.34099194\n",
+      " 0.1338343  0.10828251 0.64755726 0.9995433  0.9540582  0.9134755\n",
+      " 0.40047103 0.1640792  0.40047103 0.64755726 0.9134755  0.7590978\n",
+      " 0.5726548  0.722555  ]\n"
      ]
     }
    ],
    "source": [
-    "preds_h0 = cd.predict(X_h0)\n",
+    "preds_h0 = cd.predict(np.array(X_h0))\n",
     "labels = ['No!', 'Yes!']\n",
     "print('Drift? {}'.format(labels[preds_h0['data']['is_drift']]))\n",
     "print('p-value: {}'.format(preds_h0['data']['p_val']))"
@@ -1456,15 +1514,22 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "ELV6nSTnxfoS"
+   },
    "source": [
     "Perturbed data:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 40,
    "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "Xnu69wQdxfoS",
+    "outputId": "47bc4eb8-ebfa-45d2-d72a-815f9c5a2d02",
     "scrolled": false
    },
    "outputs": [
@@ -1474,81 +1539,79 @@
      "text": [
       "Word: fantastic -- % perturbed: 1.0\n",
       "Drift? No!\n",
-      "p-value: [0.9882611  0.79439443 0.9999727  0.9882611  0.7590978  0.8879386\n",
-      " 0.996931   0.82795686 0.64755726 0.7590978  0.85929435 0.99870795\n",
-      " 0.93558097 0.82795686 0.99365413 0.996931   0.85929435 0.8879386\n",
-      " 0.85929435 0.9540582  0.96887016 0.9801618  0.50035924 0.9998709\n",
-      " 0.96887016 0.9801618  0.8879386  0.96887016 0.9540582  0.8879386\n",
-      " 0.9995433  0.722555  ]\n",
+      "p-value: [0.9998709  0.7590978  0.99870795 0.9995433  0.9801618  0.9134755\n",
+      " 0.82795686 0.99870795 0.9882611  0.8879386  0.9801618  0.79439443\n",
+      " 0.85929435 0.96887016 0.9134755  0.996931   0.5726548  0.93558097\n",
+      " 0.9882611  0.99870795 0.93558097 0.96887016 0.85929435 0.9882611\n",
+      " 0.93558097 0.996931   0.996931   0.96887016 0.9882611  0.96887016\n",
+      " 0.8879386  0.996931  ]\n",
       "\n",
       "Word: fantastic -- % perturbed: 5.0\n",
-      "Drift? Yes!\n",
-      "p-value: [8.87938619e-01 1.99518353e-01 6.47557259e-01 1.64079204e-01\n",
-      " 2.63380647e-01 1.81119651e-01 7.22554982e-01 1.96269080e-02\n",
-      " 3.50604125e-04 1.99518353e-01 1.08282514e-01 6.85231388e-01\n",
-      " 2.63380647e-01 1.33834302e-01 8.27956855e-01 1.99518353e-01\n",
-      " 3.77843790e-02 1.48931602e-02 4.65766221e-01 4.84188050e-02\n",
-      " 6.09918952e-01 5.36054313e-01 2.82894098e-03 2.92505771e-02\n",
-      " 5.00359237e-01 7.94394433e-01 5.72654784e-01 6.15514442e-02\n",
-      " 8.87938619e-01 4.00471032e-01 3.13561678e-01 3.40991944e-01]\n",
+      "Drift? No!\n",
+      "p-value: [0.85929435 0.06155144 0.9540582  0.79439443 0.43243074 0.6852314\n",
+      " 0.722555   0.9134755  0.28769323 0.996931   0.60991895 0.19951835\n",
+      " 0.43243074 0.64755726 0.722555   0.8879386  0.18111965 0.18111965\n",
+      " 0.43243074 0.14833806 0.50035924 0.43243074 0.01489316 0.01121108\n",
+      " 0.722555   0.46576622 0.07762147 0.8879386  0.05464633 0.10828251\n",
+      " 0.03327804 0.9801618 ]\n",
       "\n",
       "Word: good -- % perturbed: 1.0\n",
       "Drift? No!\n",
-      "p-value: [0.9882611  0.99365413 0.99365413 0.9998709  0.99870795 0.99365413\n",
-      " 0.996931   0.96887016 0.9134755  0.96887016 0.99365413 0.9801618\n",
-      " 0.9134755  0.9998709  0.93558097 0.99365413 0.9801618  0.96887016\n",
-      " 0.99365413 0.9540582  0.99365413 0.996931   0.93558097 0.9995433\n",
-      " 0.93558097 0.996931   0.99365413 0.99870795 0.9801618  0.9134755\n",
-      " 0.96887016 0.9540582 ]\n",
+      "p-value: [0.99365413 0.8879386  0.99870795 0.9801618  0.99870795 0.99870795\n",
+      " 0.9134755  0.93558097 0.8879386  0.9995433  0.93558097 0.996931\n",
+      " 0.99999607 0.9995433  0.99870795 0.9801618  0.99870795 0.9801618\n",
+      " 0.8879386  0.996931   0.9134755  0.996931   0.7590978  0.99365413\n",
+      " 0.9540582  0.99870795 0.99870795 0.9998709  0.9801618  0.64755726\n",
+      " 0.9999727  0.8879386 ]\n",
       "\n",
       "Word: good -- % perturbed: 5.0\n",
       "Drift? No!\n",
-      "p-value: [0.9540582  0.82795686 0.7590978  0.5726548  0.60991895 0.3699725\n",
-      " 0.9801618  0.85929435 0.5360543  0.60991895 0.9801618  0.64755726\n",
-      " 0.28769323 0.99870795 0.8879386  0.28769323 0.60991895 0.19951835\n",
-      " 0.8879386  0.21933001 0.28769323 0.5360543  0.2406036  0.7590978\n",
-      " 0.79439443 0.34099194 0.9134755  0.40047103 0.8879386  0.31356168\n",
-      " 0.82795686 0.2406036 ]\n",
+      "p-value: [0.9882611  0.6852314  0.79439443 0.60991895 0.28769323 0.3699725\n",
+      " 0.28769323 0.6852314  0.79439443 0.31356168 0.99870795 0.85929435\n",
+      " 0.34099194 0.34099194 0.8879386  0.996931   0.96887016 0.96887016\n",
+      " 0.9540582  0.722555   0.19951835 0.9995433  0.3699725  0.722555\n",
+      " 0.1338343  0.9134755  0.5360543  0.26338065 0.85929435 0.2406036\n",
+      " 0.31356168 0.6852314 ]\n",
       "\n",
       "Word: bad -- % perturbed: 1.0\n",
       "Drift? No!\n",
-      "p-value: [0.8879386  0.99870795 0.99365413 0.85929435 0.93558097 0.6852314\n",
-      " 0.82795686 0.9540582  0.93558097 0.9540582  0.93558097 0.7590978\n",
-      " 0.6852314  0.96887016 0.9134755  0.99365413 0.46576622 0.79439443\n",
-      " 0.85929435 0.9540582  0.93558097 0.8879386  0.50035924 0.9999727\n",
-      " 0.5726548  0.9134755  0.99870795 0.9540582  0.9882611  0.8879386\n",
-      " 0.9540582  0.9134755 ]\n",
+      "p-value: [0.93558097 0.996931   0.85929435 0.9540582  0.50035924 0.64755726\n",
+      " 0.82795686 0.85929435 0.82795686 0.9882611  0.82795686 0.9540582\n",
+      " 0.21933001 0.96887016 0.93558097 0.99870795 0.79439443 0.722555\n",
+      " 0.93558097 0.93558097 0.64755726 0.99365413 0.5726548  0.9998709\n",
+      " 0.93558097 0.96887016 0.9995433  0.99365413 0.7590978  0.93558097\n",
+      " 0.9882611  0.9134755 ]\n",
       "\n",
       "Word: bad -- % perturbed: 5.0\n",
       "Drift? Yes!\n",
-      "p-value: [6.09918952e-01 1.99518353e-01 3.69972497e-01 4.00471032e-01\n",
-      " 1.81119651e-01 1.71140861e-02 8.59294355e-01 6.15514442e-02\n",
-      " 3.13561678e-01 1.64079204e-01 6.47557259e-01 3.69972497e-01\n",
-      " 2.63813617e-05 1.96269080e-02 1.20504074e-01 3.69972497e-01\n",
-      " 7.76214674e-02 3.32780443e-02 9.71045271e-02 3.69972497e-01\n",
-      " 5.46463318e-02 5.00359237e-01 4.93855441e-05 6.47557259e-01\n",
-      " 4.84188050e-02 3.69972497e-01 2.40603596e-01 3.89581337e-03\n",
-      " 4.00471032e-01 8.27956855e-01 5.36054313e-01 5.36054313e-01]\n",
+      "p-value: [4.00471032e-01 8.27956855e-01 2.87693232e-01 6.47557259e-01\n",
+      " 3.89581337e-03 1.03241683e-03 3.40991944e-01 7.59097815e-01\n",
+      " 2.82894098e-03 5.46463318e-02 1.20504074e-01 2.63380647e-01\n",
+      " 1.11190266e-05 5.46463318e-02 4.65766221e-01 7.94394433e-01\n",
+      " 9.69783217e-03 3.69972497e-01 9.35580969e-01 1.71140861e-02\n",
+      " 6.91903234e-02 7.94394433e-01 9.07998619e-05 4.00471032e-01\n",
+      " 8.27956855e-01 7.59097815e-01 1.64079204e-01 4.84188050e-02\n",
+      " 1.71140861e-02 6.85231388e-01 5.46463318e-02 5.72654784e-01]\n",
       "\n",
       "Word: horrible -- % perturbed: 1.0\n",
       "Drift? No!\n",
-      "p-value: [0.9801618  0.50035924 0.9134755  0.7590978  0.8879386  0.60991895\n",
-      " 0.9540582  0.9134755  0.5726548  0.96887016 0.85929435 0.8879386\n",
-      " 0.2406036  0.64755726 0.8879386  0.79439443 0.5726548  0.9882611\n",
-      " 0.6852314  0.85929435 0.7590978  0.7590978  0.7590978  0.9134755\n",
-      " 0.7590978  0.93558097 0.7590978  0.82795686 0.996931   0.9134755\n",
-      " 0.9801618  0.8879386 ]\n",
+      "p-value: [0.996931   0.9801618  0.96887016 0.79439443 0.79439443 0.5726548\n",
+      " 0.82795686 0.996931   0.43243074 0.93558097 0.79439443 0.82795686\n",
+      " 0.06919032 0.3699725  0.96887016 0.9540582  0.5360543  0.6852314\n",
+      " 0.60991895 0.79439443 0.9540582  0.9801618  0.40047103 0.5726548\n",
+      " 0.82795686 0.8879386  0.9540582  0.9134755  0.99365413 0.60991895\n",
+      " 0.82795686 0.79439443]\n",
       "\n",
       "Word: horrible -- % perturbed: 5.0\n",
       "Drift? Yes!\n",
-      "p-value: [7.22554982e-01 1.38413116e-05 5.46463318e-02 3.89581337e-03\n",
-      " 1.99518353e-01 4.21853358e-04 1.99518353e-01 1.81119651e-01\n",
-      " 5.37760343e-07 6.20218972e-03 1.64079204e-01 7.76214674e-02\n",
-      " 5.71402455e-15 7.42663324e-05 1.29345525e-02 9.69783217e-03\n",
-      " 1.12110768e-02 6.15514442e-02 2.40603596e-01 1.20504074e-01\n",
-      " 5.72654784e-01 2.40603596e-01 1.10792353e-04 1.96269080e-02\n",
-      " 5.32228360e-03 1.98871276e-04 1.72444014e-03 1.71140861e-02\n",
-      " 8.87938619e-01 9.71045271e-02 4.84188050e-02 8.69054198e-02]\n",
+      "p-value: [4.00471032e-01 1.48931602e-02 4.84188050e-02 1.96269080e-02\n",
+      " 1.12110768e-02 1.48931602e-02 4.00471032e-01 5.72654784e-01\n",
+      " 1.45630504e-03 1.96269080e-02 7.59097815e-01 1.72444014e-03\n",
+      " 1.30072730e-15 1.79437677e-06 2.63380647e-01 6.47557259e-01\n",
+      " 1.11478073e-06 1.99518353e-01 1.20504074e-01 4.55808453e-03\n",
+      " 7.21312594e-03 2.40603596e-01 2.24637091e-02 4.28151786e-02\n",
+      " 4.28151786e-02 7.22554982e-01 1.08282514e-01 9.07998619e-05\n",
+      " 5.36054313e-01 9.71045271e-02 1.64079204e-01 3.40991944e-01]\n",
       "\n"
      ]
     }
@@ -1556,7 +1619,7 @@
    "source": [
     "for w, probas in X_word.items():\n",
     "    for p, v in probas.items():\n",
-    "        preds = cd.predict(v)\n",
+    "        preds = cd.predict(np.array(v))\n",
     "        print('Word: {} -- % perturbed: {}'.format(w, p))\n",
     "        print('Drift? {}'.format(labels[preds['data']['is_drift']]))\n",
     "        print('p-value: {}'.format(preds['data']['p_val']))\n",
@@ -1565,7 +1628,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "ocKUZUZLxfoS"
+   },
    "source": [
     "The detector is not as sensitive as the Transformer-based K-S drift detector. The embeddings trained from scratch only trained on a small dataset and a simple model with cross-entropy loss function for 2 epochs. The pre-trained BERT model on the other hand captures semantics of the data better.\n",
     "\n",
@@ -1574,22 +1639,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
-   "metadata": {},
+   "execution_count": 41,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "-ABzIgu4xfoS",
+    "outputId": "090f7532-f86a-4e3d-d7dc-aa0248b0a674"
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "Drift? Yes!\n",
-      "p-value: [5.72654784e-01 7.26078229e-04 2.73716728e-15 3.49877549e-09\n",
-      " 1.29345525e-02 2.24637091e-02 4.95470906e-14 1.34916729e-04\n",
-      " 8.27956855e-01 4.00471032e-01 6.20218972e-03 1.97469308e-09\n",
-      " 6.15514442e-02 5.06567594e-04 5.46463318e-02 7.59097815e-01\n",
-      " 1.97830971e-07 4.56308130e-10 4.15714254e-08 4.32430744e-01\n",
-      " 8.36122004e-23 4.56308130e-10 1.12110768e-02 5.20541775e-30\n",
-      " 5.72654784e-01 9.15067773e-08 1.85489473e-08 6.85231388e-01\n",
-      " 1.54522304e-12 2.56591532e-02 2.40603596e-01 7.21312594e-03]\n"
+      "p-value: [7.22554982e-01 1.07232365e-08 3.69972497e-01 9.54058170e-01\n",
+      " 7.22554982e-01 4.84188050e-02 9.69783217e-03 1.71956726e-05\n",
+      " 8.87938619e-01 4.01514189e-05 2.54783203e-07 1.22740539e-03\n",
+      " 4.21853358e-04 3.49877549e-09 5.46463318e-02 1.79437677e-06\n",
+      " 6.91903234e-02 4.20066499e-07 3.50604125e-04 2.87693232e-01\n",
+      " 1.69780876e-14 1.69780876e-14 3.40991944e-01 2.53623026e-18\n",
+      " 2.26972293e-06 3.18301190e-08 2.40344345e-03 5.32228360e-03\n",
+      " 2.40725611e-04 2.56591532e-02 3.27475419e-07 5.69539361e-06]\n"
      ]
     }
    ],
@@ -1602,6 +1673,12 @@
   }
  ],
  "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "collapsed_sections": [],
+   "name": "cd_text_imdb.ipynb",
+   "provenance": []
+  },
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
@@ -1617,9 +1694,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.8.11"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 1
 }

--- a/doc/source/examples/cd_text_imdb.ipynb
+++ b/doc/source/examples/cd_text_imdb.ipynb
@@ -1506,7 +1506,7 @@
     }
    ],
    "source": [
-    "preds_h0 = cd.predict(np.array(X_h0))\n",
+    "preds_h0 = cd.predict(X_h0)\n",
     "labels = ['No!', 'Yes!']\n",
     "print('Drift? {}'.format(labels[preds_h0['data']['is_drift']]))\n",
     "print('p-value: {}'.format(preds_h0['data']['p_val']))"
@@ -1619,7 +1619,7 @@
    "source": [
     "for w, probas in X_word.items():\n",
     "    for p, v in probas.items():\n",
-    "        preds = cd.predict(np.array(v))\n",
+    "        preds = cd.predict(v)\n",
     "        print('Word: {} -- % perturbed: {}'.format(w, p))\n",
     "        print('Drift? {}'.format(labels[preds['data']['is_drift']]))\n",
     "        print('p-value: {}'.format(preds['data']['p_val']))\n",

--- a/doc/source/examples/od_prophet_weather.ipynb
+++ b/doc/source/examples/od_prophet_weather.ipynb
@@ -1206,7 +1206,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1220,7 +1220,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.9"
+   "version": "3.8.11"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR clarifies the use of the MMDDrift detector (with pytorch backend) in the IMDB example. An error is raised because the reference data is passed to the detector as a NumPy ndarray of `str`'s. For non-numeric data (e.g. text data), data should be passed as a list. 

The notebook is fixed by changing the `X_ref`, `X_h0` and `X_emb` variables to be `List[str]` instead of NumPy `_str` ndarrays. Since the `model` passed to `preprocess_fn` in the "Train embeddings from scratch" section expects a `ndarray`, a `preprocess_batch_fn` is added here to convert the lists to `ndarray`'s internally. Since this is a nice opportunity to make the `preprocess_batch_fn` vs `preprocess_fn` distinction clear, a note has been added explaining this. 
