### PR TITLE
Add CI to features/* branch PR's 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ on:
   pull_request:
     branches:
       - master
+      - 'features/*'
     types: [opened, synchronize, reopened, ready_for_review]
   # Trigger workflow once per week
   schedule:


### PR DESCRIPTION
Adds CI to PR's based on branches in `features/`. This will allow us to check the tests and RTD docs builds, which will be useful when working on larger projects contained in feature branches. 

I've not added the same for the notebook tests, since we can run those via manual dispatch when required. 

**Note**: To be clear, the intention is for all feature branches to be named under `features/*` from now on. This will also clean up our branches. 