### PR TITLE
Place bound on Jinja2

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -12,3 +12,5 @@ ipykernel>=5.1.0, <6.0.0 # required for executing notebooks via nbsphinx
 ipython>=7.2.0, <8.0.0 # required for executing notebooks nbsphinx
 # pandoc
 # pandoc==1.16.02 # NB: as this is not a Python library, it should be installed manually on the system or via a package manager such as `conda`
+
+jinja2<3.1.0  # temporary fix for nbconvert issue https://github.com/jupyter/nbconvert/issues/1736


### PR DESCRIPTION
Nightly CI builds failing due to jinja2 update not reflected in https://github.com/jupyter/nbconvert/issues/1736. Revert once https://github.com/jupyter/nbconvert/pull/1737 is merged and released.