### PR TITLE
Init DeepKernel RBFs inside init()

### DIFF
--- a/alibi_detect/utils/tensorflow/kernels.py
+++ b/alibi_detect/utils/tensorflow/kernels.py
@@ -108,6 +108,7 @@ class DeepKernel(tf.keras.Model):
         The kernel to apply to the projected inputs. Defaults to a Gaussian RBF with trainable bandwidth.
     kernel_b
         The kernel to apply to the raw inputs. Defaults to a Gaussian RBF with trainable bandwidth.
+        Set to None in order to use only the deep component (i.e. eps=0).
     eps
         The proportion (in [0,1]) of weight to assign to the kernel applied to raw inputs. This can be
         either specified or set to 'trainable'. Only relavent is kernel_b is not None.

--- a/alibi_detect/utils/tensorflow/kernels.py
+++ b/alibi_detect/utils/tensorflow/kernels.py
@@ -108,7 +108,6 @@ class DeepKernel(tf.keras.Model):
         The kernel to apply to the projected inputs. Defaults to a Gaussian RBF with trainable bandwidth.
     kernel_b
         The kernel to apply to the raw inputs. Defaults to a Gaussian RBF with trainable bandwidth.
-        Set to None in order to use only the deep component (i.e. eps=0).
     eps
         The proportion (in [0,1]) of weight to assign to the kernel applied to raw inputs. This can be
         either specified or set to 'trainable'. Only relavent is kernel_b is not None.
@@ -117,14 +116,14 @@ class DeepKernel(tf.keras.Model):
     def __init__(
         self,
         proj: tf.keras.Model,
-        kernel_a: Optional[tf.keras.Model] = None,
-        kernel_b: Optional[tf.keras.Model] = None,
+        kernel_a: Union[tf.keras.Model, str] = 'rbf',
+        kernel_b: Optional[Union[tf.keras.Model, str]] = 'rbf',
         eps: Union[float, str] = 'trainable'
     ) -> None:
         super().__init__()
-        if kernel_a is None:
+        if kernel_a == 'rbf':
             kernel_a = GaussianRBF(trainable=True)
-        if kernel_b is None:
+        if kernel_b == 'rbf':
             kernel_b = GaussianRBF(trainable=True)
         self.config = {'proj': proj, 'kernel_a': kernel_a, 'kernel_b': kernel_b, 'eps': eps}
         self.kernel_a = kernel_a

--- a/alibi_detect/utils/tensorflow/kernels.py
+++ b/alibi_detect/utils/tensorflow/kernels.py
@@ -117,11 +117,15 @@ class DeepKernel(tf.keras.Model):
     def __init__(
         self,
         proj: tf.keras.Model,
-        kernel_a: tf.keras.Model = GaussianRBF(trainable=True),
-        kernel_b: Optional[tf.keras.Model] = GaussianRBF(trainable=True),
+        kernel_a: Optional[tf.keras.Model] = None,
+        kernel_b: Optional[tf.keras.Model] = None,
         eps: Union[float, str] = 'trainable'
     ) -> None:
         super().__init__()
+        if kernel_a is None:
+            kernel_a = GaussianRBF(trainable=True)
+        if kernel_b is None:
+            kernel_b = GaussianRBF(trainable=True)
         self.config = {'proj': proj, 'kernel_a': kernel_a, 'kernel_b': kernel_b, 'eps': eps}
         self.kernel_a = kernel_a
         self.kernel_b = kernel_b

--- a/alibi_detect/utils/tensorflow/kernels.py
+++ b/alibi_detect/utils/tensorflow/kernels.py
@@ -149,9 +149,9 @@ class DeepKernel(tf.keras.Model):
         return tf.math.sigmoid(self.logit_eps) if self.kernel_b is not None else tf.constant(0.)
 
     def call(self, x: tf.Tensor, y: tf.Tensor) -> tf.Tensor:
-        similarity = self.kernel_a(self.proj(x), self.proj(y))
+        similarity = self.kernel_a(self.proj(x), self.proj(y))  # type: ignore
         if self.kernel_b is not None:
-            similarity = (1-self.eps)*similarity + self.eps*self.kernel_b(x, y)
+            similarity = (1-self.eps)*similarity + self.eps*self.kernel_b(x, y)  # type: ignore
         return similarity
 
     def get_config(self) -> dict:


### PR DESCRIPTION
For some reason initialising `tf.keras.Model` objects causes all available GPU memory to become occupied. This was happening upon import of `alibi_detect` due to the fact that `GaussianRBF` objects were being initialised in the definition of the `DeepKernel` class. This patch fix now sets the defaults to `None` and only initialises the `GaussianRBF` objects upon instantiation of a `DeepKernel` object.