### PR TITLE
Refactor drift detector score methods

### DIFF
--- a/alibi_detect/cd/base.py
+++ b/alibi_detect/cd/base.py
@@ -581,12 +581,8 @@ class BaseMMDDrift(BaseDetector):
         'data' contains the drift prediction and optionally the p-value, threshold and MMD metric.
         """
         # compute drift scores
-        p_val, dist, dist_permutations = self.score(x)
+        p_val, dist, distance_threshold = self.score(x)
         drift_pred = int(p_val < self.p_val)
-
-        # compute distance threshold
-        idx_threshold = int(self.p_val * len(dist_permutations))
-        distance_threshold = np.sort(dist_permutations)[::-1][idx_threshold]
 
         # update reference dataset
         if isinstance(self.update_x_ref, dict) and self.preprocess_fn is not None and self.preprocess_x_ref:

--- a/alibi_detect/cd/base.py
+++ b/alibi_detect/cd/base.py
@@ -401,7 +401,7 @@ class BaseLearnedKernelDrift(BaseDetector):
         return (x_ref_tr, x_cur_tr), (x_ref_te, x_cur_te)
 
     @abstractmethod
-    def score(self, x: Union[np.ndarray, list]) -> Tuple[float, float, np.ndarray]:
+    def score(self, x: Union[np.ndarray, list]) -> Tuple[float, float, float]:
         pass
 
     def predict(self, x: Union[np.ndarray, list], return_p_val: bool = True,
@@ -429,12 +429,8 @@ class BaseLearnedKernelDrift(BaseDetector):
             trained kernel.
         """
         # compute drift scores
-        p_val, dist, dist_permutations = self.score(x)
+        p_val, dist, distance_threshold = self.score(x)
         drift_pred = int(p_val < self.p_val)
-
-        # compute distance threshold
-        idx_threshold = int(self.p_val * len(dist_permutations))
-        distance_threshold = np.sort(dist_permutations)[::-1][idx_threshold]
 
         # update reference dataset
         if isinstance(self.update_x_ref, dict) and self.preprocess_fn is not None and self.preprocess_x_ref:

--- a/alibi_detect/cd/base.py
+++ b/alibi_detect/cd/base.py
@@ -557,7 +557,7 @@ class BaseMMDDrift(BaseDetector):
         pass
 
     @abstractmethod
-    def score(self, x: Union[np.ndarray, list]) -> Tuple[float, float, np.ndarray]:
+    def score(self, x: Union[np.ndarray, list]) -> Tuple[float, float, float]:
         pass
 
     def predict(self, x: Union[np.ndarray, list], return_p_val: bool = True, return_distance: bool = True) \

--- a/alibi_detect/cd/base.py
+++ b/alibi_detect/cd/base.py
@@ -1063,7 +1063,7 @@ class BaseContextMMDDrift(BaseDetector):
 
     @abstractmethod
     def score(self,  # type: ignore[override]
-              x: Union[np.ndarray, list], c: np.ndarray) -> Tuple[float, float, np.ndarray, Tuple]:
+              x: Union[np.ndarray, list], c: np.ndarray) -> Tuple[float, float, float, Tuple]:
         pass
 
     def predict(self,  # type: ignore[override]
@@ -1094,12 +1094,8 @@ class BaseContextMMDDrift(BaseDetector):
         and coupling matrices.
         """
         # compute drift scores
-        p_val, dist, dist_permutations, coupling = self.score(x, c)
+        p_val, dist, distance_threshold, coupling = self.score(x, c)
         drift_pred = int(p_val < self.p_val)
-
-        # compute distance threshold
-        idx_threshold = int(self.p_val * len(dist_permutations))
-        distance_threshold = np.sort(dist_permutations)[::-1][idx_threshold]
 
         # update reference dataset
         if isinstance(self.update_ref, dict) and self.preprocess_fn is not None and self.preprocess_x_ref:

--- a/alibi_detect/cd/base.py
+++ b/alibi_detect/cd/base.py
@@ -703,7 +703,7 @@ class BaseLSDDDrift(BaseDetector):
             return self.x_ref, x  # type: ignore[return-value]
 
     @abstractmethod
-    def score(self, x: Union[np.ndarray, list]) -> Tuple[float, float, np.ndarray]:
+    def score(self, x: Union[np.ndarray, list]) -> Tuple[float, float, float]:
         pass
 
     def predict(self, x: Union[np.ndarray, list], return_p_val: bool = True, return_distance: bool = True) \
@@ -727,12 +727,8 @@ class BaseLSDDDrift(BaseDetector):
         'data' contains the drift prediction and optionally the p-value, threshold and LSDD metric.
         """
         # compute drift scores
-        p_val, dist, dist_permutations = self.score(x)
+        p_val, dist, distance_threshold = self.score(x)
         drift_pred = int(p_val < self.p_val)
-
-        # compute distance threshold
-        idx_threshold = int(self.p_val * len(dist_permutations))
-        distance_threshold = np.sort(dist_permutations)[::-1][idx_threshold]
 
         # update reference dataset
         if isinstance(self.update_x_ref, dict):

--- a/alibi_detect/cd/context_aware.py
+++ b/alibi_detect/cd/context_aware.py
@@ -136,7 +136,7 @@ class ContextMMDDrift:
         """
         return self._detector.predict(x, c, return_p_val, return_distance, return_coupling)
 
-    def score(self, x: Union[np.ndarray, list], c: np.ndarray) -> Tuple[float, float, np.ndarray, Tuple]:
+    def score(self, x: Union[np.ndarray, list], c: np.ndarray) -> Tuple[float, float, float, Tuple]:
         """
         Compute the MMD based conditional test statistic, and perform a conditional permutation test to obtain a
         p-value representing the test statistic's extremity under the null hypothesis.
@@ -150,7 +150,8 @@ class ContextMMDDrift:
 
         Returns
         -------
-        p-value obtained from the conditional permutation test, the conditional MMD test statistic, the permuted
-        test statistics, and a tuple containing the coupling matrices (Wref,ref, Wtest,test, Wref,test).
+        p-value obtained from the conditional permutation test, the conditional MMD test statistic, the test
+        statistic threshold above which drift is flagged, and a tuple containing the coupling matrices
+        (W_{ref,ref}, W_{test,test}, W_{ref,test}).
         """
         return self._detector.score(x, c)

--- a/alibi_detect/cd/lsdd.py
+++ b/alibi_detect/cd/lsdd.py
@@ -109,7 +109,7 @@ class LSDDDrift:
         """
         return self._detector.predict(x, return_p_val, return_distance)
 
-    def score(self, x: Union[np.ndarray, list]) -> Tuple[float, float, np.ndarray]:
+    def score(self, x: Union[np.ndarray, list]) -> Tuple[float, float, float]:
         """
         Compute the p-value resulting from a permutation test using the least-squares density
         difference as a distance measure between the reference data and the data to be tested.
@@ -121,7 +121,7 @@ class LSDDDrift:
 
         Returns
         -------
-        p-value obtained from the permutation test, the LSDD between the reference and test set
-        and the LSDD values from the permutation test.
+        p-value obtained from the permutation test, the LSDD between the reference and test set,
+        and the LSDD threshold above which drift is flagged.
         """
         return self._detector.score(x)

--- a/alibi_detect/cd/mmd.py
+++ b/alibi_detect/cd/mmd.py
@@ -115,7 +115,7 @@ class MMDDrift:
         """
         return self._detector.predict(x, return_p_val, return_distance)
 
-    def score(self, x: Union[np.ndarray, list]) -> Tuple[float, float, np.ndarray]:
+    def score(self, x: Union[np.ndarray, list]) -> Tuple[float, float, float]:
         """
         Compute the p-value resulting from a permutation test using the maximum mean discrepancy
         as a distance measure between the reference data and the data to be tested.
@@ -127,7 +127,7 @@ class MMDDrift:
 
         Returns
         -------
-        p-value obtained from the permutation test, the MMD^2 between the reference and test set
-        and the MMD^2 values from the permutation test.
+        p-value obtained from the permutation test, the MMD^2 between the reference and test set,
+        and the MMD^2 threshold above which drift is flagged.
         """
         return self._detector.score(x)

--- a/alibi_detect/cd/pytorch/lsdd.py
+++ b/alibi_detect/cd/pytorch/lsdd.py
@@ -122,7 +122,7 @@ class LSDDDriftTorch(BaseLSDDDrift):
         x_ref_eff = x_ref[non_c_inds]  # the effective reference set
         self.k_xc = self.kernel(x_ref_eff, self.kernel_centers)
 
-    def score(self, x: Union[np.ndarray, list]) -> Tuple[float, float, np.ndarray]:
+    def score(self, x: Union[np.ndarray, list]) -> Tuple[float, float, float]:
         """
         Compute the p-value resulting from a permutation test using the least-squares density
         difference as a distance measure between the reference data and the data to be tested.
@@ -162,8 +162,8 @@ class LSDDDriftTorch(BaseLSDDDrift):
         lsdd_permuted, _, lsdd = permed_lsdds(  # type: ignore
             k_all_c, x_perms, y_perms, self.H, lam_rd_max=self.lambda_rd_max, return_unpermed=True
         )
+        p_val = (lsdd <= lsdd_permuted).float().mean()
+
         idx_threshold = int(self.p_val * len(lsdd_permuted))
         distance_threshold = torch.sort(lsdd_permuted, descending=True).values[idx_threshold]
-
-        p_val = (lsdd <= lsdd_permuted).float().mean()
         return float(p_val.cpu()), float(lsdd.cpu().numpy()), distance_threshold.cpu().numpy()

--- a/alibi_detect/cd/pytorch/lsdd.py
+++ b/alibi_detect/cd/pytorch/lsdd.py
@@ -134,8 +134,8 @@ class LSDDDriftTorch(BaseLSDDDrift):
 
         Returns
         -------
-        p-value obtained from the permutation test, the LSDD between the reference and test set
-        and the LSDD values from the permutation test.
+        p-value obtained from the permutation test, the LSDD between the reference and test set,
+        and the LSDD threshold above which drift is flagged.
         """
         x_ref, x = self.preprocess(x)
         x_ref = torch.from_numpy(x_ref).to(self.device)  # type: ignore[assignment]
@@ -162,6 +162,8 @@ class LSDDDriftTorch(BaseLSDDDrift):
         lsdd_permuted, _, lsdd = permed_lsdds(  # type: ignore
             k_all_c, x_perms, y_perms, self.H, lam_rd_max=self.lambda_rd_max, return_unpermed=True
         )
+        idx_threshold = int(self.p_val * len(lsdd_permuted))
+        distance_threshold = torch.sort(lsdd_permuted, descending=True).values[idx_threshold]
 
         p_val = (lsdd <= lsdd_permuted).float().mean()
-        return float(p_val.cpu()), float(lsdd.cpu().numpy()), lsdd_permuted.cpu().numpy()
+        return float(p_val.cpu()), float(lsdd.cpu().numpy()), distance_threshold.cpu().numpy()

--- a/alibi_detect/cd/pytorch/mmd.py
+++ b/alibi_detect/cd/pytorch/mmd.py
@@ -102,7 +102,7 @@ class MMDDriftTorch(BaseMMDDrift):
         kernel_mat = torch.cat([torch.cat([k_xx, k_xy], 1), torch.cat([k_xy.T, k_yy], 1)], 0)
         return kernel_mat
 
-    def score(self, x: Union[np.ndarray, list]) -> Tuple[float, float, np.ndarray]:
+    def score(self, x: Union[np.ndarray, list]) -> Tuple[float, float, float]:
         """
         Compute the p-value resulting from a permutation test using the maximum mean discrepancy
         as a distance measure between the reference data and the data to be tested.

--- a/alibi_detect/cd/tensorflow/context_aware.py
+++ b/alibi_detect/cd/tensorflow/context_aware.py
@@ -156,7 +156,7 @@ class ContextMMDDriftTF(BaseContextMMDDrift):
         # compute distance threshold
         idx_threshold = int(self.p_val * len(permuted_stats))
         distance_threshold = np.sort(permuted_stats)[::-1][idx_threshold]
-        return p_val.numpy().item(), stat.numpy().item(), distance_threshold.numpy(), coupling
+        return p_val.numpy().item(), stat.numpy().item(), distance_threshold, coupling
 
     def _cmmd(self, K: tf.Tensor, L: tf.Tensor, bools: tf.Tensor, L_held: tf.Tensor = None) \
             -> Tuple[tf.Tensor, tf.Tensor, tf.Tensor, tf.Tensor]:

--- a/alibi_detect/cd/tensorflow/context_aware.py
+++ b/alibi_detect/cd/tensorflow/context_aware.py
@@ -98,7 +98,7 @@ class ContextMMDDriftTF(BaseContextMMDDrift):
         self.clf = _SVCDomainClf(self.c_kernel)
 
     def score(self,  # type: ignore[override]
-              x: Union[np.ndarray, list], c: np.ndarray) -> Tuple[float, float, np.ndarray, Tuple]:
+              x: Union[np.ndarray, list], c: np.ndarray) -> Tuple[float, float, float, Tuple]:
         """
         Compute the MMD based conditional test statistic, and perform a conditional permutation test to obtain a
         p-value representing the test statistic's extremity under the null hypothesis.
@@ -112,8 +112,9 @@ class ContextMMDDriftTF(BaseContextMMDDrift):
 
         Returns
         -------
-        p-value obtained from the conditional permutation test, the conditional MMD test statistic, the permuted
-        test statistics, and a tuple containing the coupling matrices (Wref,ref, Wtest,test, Wref,test).
+        p-value obtained from the conditional permutation test, the conditional MMD test statistic, the test
+        statistic threshold above which drift is flagged, and a tuple containing the coupling matrices
+        (W_{ref,ref}, W_{test,test}, W_{ref,test}).
         """
         x_ref, x = self.preprocess(x)
 
@@ -152,7 +153,10 @@ class ContextMMDDriftTF(BaseContextMMDDrift):
         p_val = tf.reduce_mean(tf.cast(stat <= permuted_stats, float))
         coupling = (coupling_xx.numpy(), coupling_yy.numpy(), coupling_xy.numpy())
 
-        return p_val.numpy().item(), stat.numpy().item(), permuted_stats.numpy(), coupling
+        # compute distance threshold
+        idx_threshold = int(self.p_val * len(permuted_stats))
+        distance_threshold = np.sort(permuted_stats)[::-1][idx_threshold]
+        return p_val.numpy().item(), stat.numpy().item(), distance_threshold.numpy(), coupling
 
     def _cmmd(self, K: tf.Tensor, L: tf.Tensor, bools: tf.Tensor, L_held: tf.Tensor = None) \
             -> Tuple[tf.Tensor, tf.Tensor, tf.Tensor, tf.Tensor]:

--- a/alibi_detect/cd/tensorflow/learned_kernel.py
+++ b/alibi_detect/cd/tensorflow/learned_kernel.py
@@ -141,7 +141,7 @@ class LearnedKernelDriftTF(BaseLearnedKernelDrift):
 
             return mmd2_est/tf.math.sqrt(reg_var_est)
 
-    def score(self, x: Union[np.ndarray, list]) -> Tuple[float, float, np.ndarray]:
+    def score(self, x: Union[np.ndarray, list]) -> Tuple[float, float, float]:
         """
         Compute the p-value resulting from a permutation test using the maximum mean discrepancy
         as a distance measure between the reference data and the data to be tested. The kernel
@@ -154,8 +154,8 @@ class LearnedKernelDriftTF(BaseLearnedKernelDrift):
 
         Returns
         -------
-        p-value obtained from the permutation test, the MMD^2 between the reference and test set
-        and the MMD^2 values from the permutation test.
+        p-value obtained from the permutation test, the MMD^2 between the reference and test set,
+        and the MMD^2 threshold above which drift is flagged.
         """
         x_ref, x_cur = self.preprocess(x)
         (x_ref_tr, x_cur_tr), (x_ref_te, x_cur_te) = self.get_splits(x_ref, x_cur)
@@ -177,7 +177,10 @@ class LearnedKernelDriftTF(BaseLearnedKernelDrift):
                 for _ in range(self.n_permutations)]
         )
         p_val = (mmd2 <= mmd2_permuted).mean()
-        return p_val, mmd2, mmd2_permuted
+
+        idx_threshold = int(self.p_val * len(mmd2_permuted))
+        distance_threshold = np.sort(mmd2_permuted)[::-1][idx_threshold]
+        return p_val, mmd2, distance_threshold
 
     @staticmethod
     def trainer(

--- a/alibi_detect/cd/tensorflow/lsdd.py
+++ b/alibi_detect/cd/tensorflow/lsdd.py
@@ -106,7 +106,7 @@ class LSDDDriftTF(BaseLSDDDrift):
         x_ref_eff = tf.gather(x_ref, non_c_inds)  # the effective reference set
         self.k_xc = self.kernel(x_ref_eff, self.kernel_centers)
 
-    def score(self, x: Union[np.ndarray, list]) -> Tuple[float, float, np.ndarray]:
+    def score(self, x: Union[np.ndarray, list]) -> Tuple[float, float, float]:
         """
         Compute the p-value resulting from a permutation test using the least-squares density
         difference as a distance measure between the reference data and the data to be tested.
@@ -118,8 +118,8 @@ class LSDDDriftTF(BaseLSDDDrift):
 
         Returns
         -------
-        p-value obtained from the permutation test, the LSDD between the reference and test set
-        and the LSDD values from the permutation test.
+        p-value obtained from the permutation test, the LSDD between the reference and test set,
+        and the LSDD threshold above which drift is flagged.
         """
         x_ref, x = self.preprocess(x)
 
@@ -144,6 +144,8 @@ class LSDDDriftTF(BaseLSDDDrift):
         lsdd_permuted, _, lsdd = permed_lsdds(  # type: ignore
             k_all_c, x_perms, y_perms, self.H, lam_rd_max=self.lambda_rd_max, return_unpermed=True
         )
+        idx_threshold = int(self.p_val * len(lsdd_permuted))
+        distance_threshold = np.sort(lsdd_permuted)[::-1][idx_threshold]
 
         p_val = tf.reduce_mean(tf.cast(lsdd <= lsdd_permuted, float))
-        return float(p_val), float(lsdd), lsdd_permuted.numpy()
+        return float(p_val), float(lsdd), float(distance_threshold)

--- a/alibi_detect/cd/tensorflow/lsdd.py
+++ b/alibi_detect/cd/tensorflow/lsdd.py
@@ -144,8 +144,8 @@ class LSDDDriftTF(BaseLSDDDrift):
         lsdd_permuted, _, lsdd = permed_lsdds(  # type: ignore
             k_all_c, x_perms, y_perms, self.H, lam_rd_max=self.lambda_rd_max, return_unpermed=True
         )
+        p_val = tf.reduce_mean(tf.cast(lsdd <= lsdd_permuted, float))
+
         idx_threshold = int(self.p_val * len(lsdd_permuted))
         distance_threshold = np.sort(lsdd_permuted)[::-1][idx_threshold]
-
-        p_val = tf.reduce_mean(tf.cast(lsdd <= lsdd_permuted, float))
         return float(p_val), float(lsdd), float(distance_threshold)

--- a/alibi_detect/cd/tensorflow/mmd.py
+++ b/alibi_detect/cd/tensorflow/mmd.py
@@ -89,7 +89,7 @@ class MMDDriftTF(BaseMMDDrift):
         kernel_mat = tf.concat([tf.concat([k_xx, k_xy], 1), tf.concat([tf.transpose(k_xy, (1, 0)), k_yy], 1)], 0)
         return kernel_mat
 
-    def score(self, x: Union[np.ndarray, list]) -> Tuple[float, float, np.ndarray]:
+    def score(self, x: Union[np.ndarray, list]) -> Tuple[float, float, float]:
         """
         Compute the p-value resulting from a permutation test using the maximum mean discrepancy
         as a distance measure between the reference data and the data to be tested.
@@ -118,4 +118,5 @@ class MMDDriftTF(BaseMMDDrift):
         # compute distance threshold
         idx_threshold = int(self.p_val * len(mmd2_permuted))
         distance_threshold = np.sort(mmd2_permuted)[::-1][idx_threshold]
+        print(type(p_val), type(mmd2), type(distance_threshold))
         return p_val, mmd2, distance_threshold

--- a/alibi_detect/cd/tensorflow/mmd.py
+++ b/alibi_detect/cd/tensorflow/mmd.py
@@ -101,8 +101,8 @@ class MMDDriftTF(BaseMMDDrift):
 
         Returns
         -------
-        p-value obtained from the permutation test, the MMD^2 between the reference and test set
-        and the MMD^2 values from the permutation test.
+        p-value obtained from the permutation test, the MMD^2 between the reference and test set,
+        and the MMD^2 threshold above which drift is flagged.
         """
         x_ref, x = self.preprocess(x)
         # compute kernel matrix, MMD^2 and apply permutation test using the kernel matrix
@@ -115,4 +115,7 @@ class MMDDriftTF(BaseMMDDrift):
              for _ in range(self.n_permutations)]
         )
         p_val = (mmd2 <= mmd2_permuted).mean()
-        return p_val, mmd2, mmd2_permuted
+        # compute distance threshold
+        idx_threshold = int(self.p_val * len(mmd2_permuted))
+        distance_threshold = np.sort(mmd2_permuted)[::-1][idx_threshold]
+        return p_val, mmd2, distance_threshold

--- a/alibi_detect/cd/tensorflow/mmd.py
+++ b/alibi_detect/cd/tensorflow/mmd.py
@@ -118,5 +118,4 @@ class MMDDriftTF(BaseMMDDrift):
         # compute distance threshold
         idx_threshold = int(self.p_val * len(mmd2_permuted))
         distance_threshold = np.sort(mmd2_permuted)[::-1][idx_threshold]
-        print(type(p_val), type(mmd2), type(distance_threshold))
         return p_val, mmd2, distance_threshold


### PR DESCRIPTION
This PR moves the `distance_threshold` computation from `.predict()` to `.score()` methods, for all drift detectors that perform permutation tests. 

This simplifies detector `predict` methods, and aids consistency between the existing `MMDDrift` detectors and the new linear-time MMD detectors introduced by #475.