### PR TITLE
Update to mypy 0.9

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,9 @@ repos:
     hooks:
       - id: flake8
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.812
+    rev: v0.942
     hooks:
       - id: mypy
+        additional_dependencies: [
+          types-requests>=2.25.0,
+        ]

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,7 +1,8 @@
 # development dependencies (see docs.txt for documentation building dependencies)
 # linting and static type-checking
 flake8>=3.7.7, <5.0.0
-mypy>=0.812, <0.900
+mypy~=0.900
+types-requests>=2.25.0, <2.28.0
 # testing
 pytest>=5.3.5, <8.0.0
 pytest-cov>=2.6.1, <4.0.0


### PR DESCRIPTION
Update to mypy 0.900. This is a precursor for #485.

This requires the installation of third-party type stubs, since they are no longer included in mypy (see [here](http://mypy-lang.blogspot.com/2021/06/mypy-0900-released.html)). 

The type stub packages can be installed with `mypy --install-types`, but this PR installs them via `requirements/dev.txt` so that the stub package versions can be bounded for reproducibility. 