### PR TITLE
Random seed utilities

### DIFF
--- a/alibi_detect/utils/random.py
+++ b/alibi_detect/utils/random.py
@@ -1,0 +1,65 @@
+from contextlib import contextmanager
+import random
+import numpy as np
+import os
+from alibi_detect.utils.frameworks import has_pytorch, has_tensorflow
+
+if has_tensorflow:
+    import tensorflow as tf
+if has_pytorch:
+    import torch
+
+
+def set_seed(seed):
+    """
+    Sets the Python, NumPy, TensorFlow and PyTorch random seeds (if installed).
+    """
+    os.environ['PYTHONHASHSEED'] = str(seed)
+    random.seed(seed)
+    np.random.seed(seed)
+    if has_tensorflow:
+        tf.random.set_seed(seed)
+    if has_pytorch:
+        torch.manual_seed(seed)
+
+
+def get_seed() -> int:
+    """
+    Gets the seed set by :func:`set_seed`.
+
+    Example
+    -------
+    from alibi_detect.utils import set_seed, get_seed
+    set_seed(42)
+    get_seed()
+    >>> 42
+    """
+    return np.random.get_state()[1][0]  # type: ignore[index]
+
+
+@contextmanager
+def fixed_seed(seed: int):
+    """
+    A context manager to run with a requested random seed (applied to all the RNG's set by
+    :func:`alibi_detect.utils.random.set_seeds`).
+
+    Example
+    -------
+    set_seed(0)
+    with fixed_seed(42):
+        dd = cd.LSDDDrift(X_ref)  # seeds equal 42 here
+        p_val = dd.predict(X_h0)['data']['p_val']
+    # seeds equal 0 here
+
+    Warning
+    -------
+    To ensure random seeds are reset to their original values upon exit of the context manager, it is
+    recommended to use :func:`alibi_detect.utils.random.set_seed` rather than `tf.random.set_seed` etc
+    individually when using this context manager.
+    """
+    orig_seed = get_seed()
+    set_seed(seed)
+    try:
+        yield
+    finally:
+        set_seed(orig_seed)

--- a/alibi_detect/utils/tests/conftest.py
+++ b/alibi_detect/utils/tests/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+
+
+@pytest.fixture
+def seed(pytestconfig):
+    """
+    Returns the random seed set by pytest-randomly.
+    """
+    return pytestconfig.getoption("randomly_seed")

--- a/alibi_detect/utils/tests/test_random.py
+++ b/alibi_detect/utils/tests/test_random.py
@@ -1,0 +1,29 @@
+from alibi_detect.utils.random import set_seed, get_seed, fixed_seed
+
+
+def test_set_get_seed(seed):
+    """
+    Tests the set_seed and get_seed fuctions.
+    """
+    # Check initial seed within test is the one set by pytest-randomly
+    current_seed = get_seed()
+    assert current_seed == seed
+
+    # Set another seed and check
+    new_seed = seed + 42
+    set_seed(new_seed)
+    current_seed = get_seed()
+    assert current_seed == new_seed
+
+
+def test_fixed_seed(seed):
+    """
+    Tests the fixed_seed context manager.
+    """
+    tmp_seed = seed + 42
+    with fixed_seed(tmp_seed):
+        # Check seed inside of context manager
+        assert get_seed() == tmp_seed
+
+    # Check seeds were reset upon exit of context manager
+    assert get_seed() == seed

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -7,6 +7,7 @@ types-requests>=2.25.0, <2.28.0
 pytest>=5.3.5, <8.0.0
 pytest-cov>=2.6.1, <4.0.0
 pytest-xdist>=1.28.0, <3.0.0 # for distributed testing, currently unused (see setup.cfg)
+pytest-randomly>=3.5.0, <4.0.0
 pytest-timeout>=1.4.2, <3.0.0 # for notebook tests
 jupytext>=1.12.0, <2.0.0 # for notebook tests
 ipykernel>=5.1.0, <6.0.0 # for notebook tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,7 @@
+[options.entry_points]
+pytest_randomly.random_seeder =
+    reseed = alibi_detect.utils.random:set_seed
+
 [aliases]
 test=pytest
 
@@ -6,6 +10,7 @@ addopts =
     --tb native
     -W ignore
     --cov=alibi_detect
+    --randomly-dont-reorganize
     #-n auto
     #--forked
 


### PR DESCRIPTION
This PR adds utility functions to get and set seeds for the Python, Numpy, TensorFlow and PyTorch random number generators. 

### Motivation

Some detectors such as `MMDDrift` and `LSDDDrift` involve operations using NumPy, TensorFlow and/or PyTorch random number generators. The resulting non-deterministic behavior is a problem for testing, as it prevents us performing checks such as:

```
random.seed(42)
np.random.seed(42)
tf.random.set_seed(42)

detector1 = MMDDrift(X_ref, ...)
preds1 = detector1.predict(x_h0)

detector2 = MMDDrift(X_ref, ...)
preds2 = detector2.predict(x_h0)

assert preds1['data']['p_val'] == preds2['data']['p_val']
```
Setting all random seeds (with `np.random.seed(), tf.random.set_seed()` etc) at the start of the test is insufficient to provide determinism here, since the operations on the first detector will still cycle through the RNG states such that the second detector would see a different RNG state. To ensure determinism we would instead have to set seeds again before the init and prediction of the second detector.

Setting global random seeds in individual `pytest` functions is also undesriable in general, and leads to a difficult-to-maintain and unpredictable test suite.

### Solution

This PR addresses the above through two changes:

1. Introduces the use of [pytest-randomly](https://github.com/pytest-dev/pytest-randomly) for testing. This package manages the random seeds used for each test. The seed is randomly changed for each test, which avoids us being tricked by tests passing due to a "friendly" hardcoded random state. Importantly, the random seed is reported for each test e.g.:

   `Using --randomly-seed=1553614239`

   and a test can then be repeated with a given random seed for debugging purposes:

   `pytest --randomly-seed=1234 alibi_detect -k <name_of_failed_test>`

2. A new submodule `alibi_detect.utils.random` is introduced. This contains functionality to set and get RNG seeds (the relevent seeds for NumPy, TensorFlow, PyTorch etc are all set at once). A context manager `fixed_seed` is also introduced to enable select lines of code to be run with a given seed in an isolated fashion, e.g.:

   ```python
   with fixed_seed(42):
      detector1 = MMDDrift(X_ref, ...)
      preds1 = detector1.predict(x_h0)

   with fixed_seed(42):
      detector2 = MMDDrift(X_ref, ...)
      preds2 = detector2.predict(x_h0)

   assert preds1['data']['p_val'] == preds2['data']['p_val']
   ```
   The `fixed_seed`'s above set all the random seeds to 42 within the `with` block, but they are reset to their original values upon exit of the block.

The `alibi_detect.utils.random` has been made public as it might be quite useful for use in example notebooks, experiments etc.

**Note**: If we decided we didn't want the new utilities public, we could hide it within `tests` instead, however we would not be able to set `set_seeds` as an `entry_point` for `pytest`, meaning `pytest` wouldn't use our custom seed setter internally (our custom one also sets the TF and torch random seeds, whereas the `pytest` `reseed` function only sets Python and Numpy seeds).