### PR TITLE
Revert "Replace autodoc with autoapi (#482)"

### DIFF
--- a/doc/source/ad/methods/adversarialae.ipynb
+++ b/doc/source/ad/methods/adversarialae.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[source](../../api/alibi_detect/ad/adversarialae/index.rst)"
+    "[source](../../api/alibi_detect.ad.adversarialae.rst)"
    ]
   },
   {

--- a/doc/source/ad/methods/modeldistillation.ipynb
+++ b/doc/source/ad/methods/modeldistillation.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[source](../../api/alibi_detect/ad/model_distillation/index.rst)"
+    "[source](../../api/alibi_detect.ad.model_distillation.rst)"
    ]
   },
   {
@@ -160,7 +160,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -174,7 +174,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.11"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/doc/source/cd/background.md
+++ b/doc/source/cd/background.md
@@ -274,8 +274,11 @@ the reconstruction loss, e.g. if MSE is used:
 $\phi, \psi = \text{arg} \min_{\phi, \psi}\, \lVert \mathbf{X}-(\phi \circ \psi)\mathbf{X}\rVert^2$.
 However, untrained (randomly initialised) autoencoders can also be used.
 For an example, a `pytorch` autoencoder can be incorporated into a
-detector by packaging it as a callable function using {func}`~alibi_detect.cd.pytorch.preprocess.preprocess_drift`
-and {func}`~functools.partial`: 
+detector by packaging it as a callable function using
+`preprocess_drift` (from
+[alibi_detect.cd.pytorch.preprocess](../api/alibi_detect.cd.pytorch.preprocess.rst))
+and `partial` (see
+[here](https://docs.python.org/3/library/functools.html#functools.partial)):
 
 ```python
 encoder_net = torch.nn.Sequential(...)
@@ -309,7 +312,10 @@ is encouraging since this allows the user to repurpose existing
 black-box models for use as drift detectors. The syntax for
 incorporating existing models into drift detectors is similar to the
 previous autoencoder example, with the added step of using
-{class}`~alibi_detect.cd.tensorflow.preprocess.HiddenOutput`
+`HiddenOutput`
+([alibi_detect.cd.tensorflow.preprocess](../api/alibi_detect.cd.tensorflow.preprocess.rst)
+or
+[alibi_detect.cd.pytorch.preprocess](../api/alibi_detect.cd.pytorch.preprocess.rst))
 to select the model’s network layer to extract outputs from. The code
 snippet below is borrowed from [Maximum Mean Discrepancy drift detector
 on CIFAR-10](../examples/cd_mmd_cifar10.ipynb), where the softmax
@@ -391,7 +397,8 @@ reviews](../examples/cd_text_imdb.ipynb) example, where the
 768-dimensional embeddings from the BERT model are passed through an
 untrained AutoEncoder to reduce their dimensionality. Alibi Detect
 allows various types of embeddings to be extracted from transformer
-models, using {class}`~alibi_detect.models.tensorflow.embedding.TransformerEmbedding`.
+models, as discussed in
+[alibi_detect.models.tensorflow.embedding](../api/alibi_detect.models.tensorflow.embedding.rst).
 
 #### Graph data
 

--- a/doc/source/cd/background.md
+++ b/doc/source/cd/background.md
@@ -391,7 +391,6 @@ reviews](../examples/cd_text_imdb.ipynb) example, where the
 768-dimensional embeddings from the BERT model are passed through an
 untrained AutoEncoder to reduce their dimensionality. Alibi Detect
 allows various types of embeddings to be extracted from transformer
-models, as discussed in
 models, using {class}`~alibi_detect.models.tensorflow.embedding.TransformerEmbedding`.
 
 #### Graph data

--- a/doc/source/cd/background.md
+++ b/doc/source/cd/background.md
@@ -274,11 +274,8 @@ the reconstruction loss, e.g. if MSE is used:
 $\phi, \psi = \text{arg} \min_{\phi, \psi}\, \lVert \mathbf{X}-(\phi \circ \psi)\mathbf{X}\rVert^2$.
 However, untrained (randomly initialised) autoencoders can also be used.
 For an example, a `pytorch` autoencoder can be incorporated into a
-detector by packaging it as a callable function using
-`preprocess_drift` (from
-[alibi_detect.cd.pytorch.preprocess](../api/alibi_detect.cd.pytorch.preprocess.rst))
-and `partial` (see
-[here](https://docs.python.org/3/library/functools.html#functools.partial)):
+detector by packaging it as a callable function using {func}`~alibi_detect.cd.pytorch.preprocess.preprocess_drift`
+and {func}`~functools.partial`: 
 
 ```python
 encoder_net = torch.nn.Sequential(...)
@@ -312,10 +309,7 @@ is encouraging since this allows the user to repurpose existing
 black-box models for use as drift detectors. The syntax for
 incorporating existing models into drift detectors is similar to the
 previous autoencoder example, with the added step of using
-`HiddenOutput`
-([alibi_detect.cd.tensorflow.preprocess](../api/alibi_detect.cd.tensorflow.preprocess.rst)
-or
-[alibi_detect.cd.pytorch.preprocess](../api/alibi_detect.cd.pytorch.preprocess.rst))
+{class}`~alibi_detect.cd.tensorflow.preprocess.HiddenOutput`
 to select the model’s network layer to extract outputs from. The code
 snippet below is borrowed from [Maximum Mean Discrepancy drift detector
 on CIFAR-10](../examples/cd_mmd_cifar10.ipynb), where the softmax
@@ -398,7 +392,7 @@ reviews](../examples/cd_text_imdb.ipynb) example, where the
 untrained AutoEncoder to reduce their dimensionality. Alibi Detect
 allows various types of embeddings to be extracted from transformer
 models, as discussed in
-[alibi_detect.models.tensorflow.embedding](../api/alibi_detect.models.tensorflow.embedding.rst).
+models, using {class}`~alibi_detect.models.tensorflow.embedding.TransformerEmbedding`.
 
 #### Graph data
 

--- a/doc/source/cd/methods/chisquaredrift.ipynb
+++ b/doc/source/cd/methods/chisquaredrift.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[source](../../api/alibi_detect/cd/chisquare/index.rst)"
+    "[source](../../api/alibi_detect.cd.chisquare.rst)"
    ]
   },
   {
@@ -126,7 +126,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.11"
+   "version": "3.9.5"
   }
  },
  "nbformat": 4,

--- a/doc/source/cd/methods/classifierdrift.ipynb
+++ b/doc/source/cd/methods/classifierdrift.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[source](../../api/alibi_detect/cd/classifier/index.rst)"
+    "[source](../../api/alibi_detect.cd.classifier.rst)"
    ]
   },
   {
@@ -192,7 +192,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -206,7 +206,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.11"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/doc/source/cd/methods/contextmmddrift.ipynb
+++ b/doc/source/cd/methods/contextmmddrift.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[source](../../api/alibi_detect/cd/context_aware/index.rst)"
+    "[source](../../api/alibi_detect.cd.context_aware.rst)"
    ]
   },
   {
@@ -156,7 +156,7 @@
    "hash": "ffba93b5284319fb7a107c8eacae647f441487dcc7e0323a4c0d3feb66ea8c5e"
   },
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -170,7 +170,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.11"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/doc/source/cd/methods/cvmdrift.ipynb
+++ b/doc/source/cd/methods/cvmdrift.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[source](../../api/alibi_detect/cd/cvm/index.rst)"
+    "[source](../../api/alibi_detect.cd.cvm.rst)"
    ]
   },
   {

--- a/doc/source/cd/methods/fetdrift.ipynb
+++ b/doc/source/cd/methods/fetdrift.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[source](../../api/alibi_detect/cd/fet/index.rst)"
+    "[source](../../api/alibi_detect.cd.fet.rst)"
    ]
   },
   {

--- a/doc/source/cd/methods/ksdrift.ipynb
+++ b/doc/source/cd/methods/ksdrift.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[source](../../api/alibi_detect/cd/ks/index.rst)"
+    "[source](../../api/alibi_detect.cd.ks.rst)"
    ]
   },
   {
@@ -144,7 +144,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.11"
+   "version": "3.9.5"
   }
  },
  "nbformat": 4,

--- a/doc/source/cd/methods/learnedkerneldrift.ipynb
+++ b/doc/source/cd/methods/learnedkerneldrift.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[source](../../api/alibi_detect/cd/learned_kernel/index.rst)"
+    "[source](../../api/alibi_detect.cd.learned_kernel.rst)"
    ]
   },
   {
@@ -192,7 +192,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -206,7 +206,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.11"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,

--- a/doc/source/cd/methods/lsdddrift.ipynb
+++ b/doc/source/cd/methods/lsdddrift.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[source](../../api/alibi_detect/cd/lsdd/index.rst)"
+    "[source](../../api/alibi_detect.cd.lsdd.rst)"
    ]
   },
   {
@@ -213,7 +213,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.11"
+   "version": "3.9.5"
   }
  },
  "nbformat": 4,

--- a/doc/source/cd/methods/mmddrift.ipynb
+++ b/doc/source/cd/methods/mmddrift.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[source](../../api/alibi_detect/cd/mmd/index.rst)"
+    "[source](../../api/alibi_detect.cd.mmd.rst)"
    ]
   },
   {

--- a/doc/source/cd/methods/modeluncdrift.ipynb
+++ b/doc/source/cd/methods/modeluncdrift.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[source](../../api/alibi_detect/cd/model_uncertainty/index.rst)"
+    "[source](../../api/alibi_detect.cd.model_uncertainty.rst)"
    ]
   },
   {
@@ -155,7 +155,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -169,7 +169,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.11"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/doc/source/cd/methods/onlinecvmdrift.ipynb
+++ b/doc/source/cd/methods/onlinecvmdrift.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[source](../../api/alibi_detect/cd/cvm_online/index.rst)"
+    "[source](../../api/alibi_detect.cd.cvm_online.rst)"
    ]
   },
   {
@@ -141,7 +141,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.11"
+   "version": "3.9.5"
   }
  },
  "nbformat": 4,

--- a/doc/source/cd/methods/onlinefetdrift.ipynb
+++ b/doc/source/cd/methods/onlinefetdrift.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[source](../../api/alibi_detect/cd/fet_online/index.rst)"
+    "[source](../../api/alibi_detect.cd.fet_online.rst)"
    ]
   },
   {
@@ -167,7 +167,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.11"
+   "version": "3.9.5"
   }
  },
  "nbformat": 4,

--- a/doc/source/cd/methods/onlinelsdddrift.ipynb
+++ b/doc/source/cd/methods/onlinelsdddrift.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[source](../../api/alibi_detect/cd/lsdd_online/index.rst)"
+    "[source](../../api/alibi_detect.cd.lsdd_online.rst)"
    ]
   },
   {

--- a/doc/source/cd/methods/onlinemmddrift.ipynb
+++ b/doc/source/cd/methods/onlinemmddrift.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[source](../../api/alibi_detect/cd/mmd_online/index.rst)"
+    "[source](../../api/alibi_detect.cd.mmd_online.rst)"
    ]
   },
   {
@@ -215,7 +215,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.11"
+   "version": "3.9.5"
   }
  },
  "nbformat": 4,

--- a/doc/source/cd/methods/spotthediffdrift.ipynb
+++ b/doc/source/cd/methods/spotthediffdrift.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[source](../../api/alibi_detect/cd/spot_the_diff/index.rst)"
+    "[source](../../api/alibi_detect.cd.spot_the_diff.rst)"
    ]
   },
   {

--- a/doc/source/cd/methods/tabulardrift.ipynb
+++ b/doc/source/cd/methods/tabulardrift.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[source](../../api/alibi_detect/cd/tabular/index.rst)"
+    "[source](../../api/alibi_detect.cd.tabular.rst)"
    ]
   },
   {
@@ -113,7 +113,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -127,7 +127,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.11"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -44,6 +44,7 @@ release = __version__
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    "sphinx.ext.autodoc",
     "sphinx.ext.doctest",
     "sphinx.ext.intersphinx",
     "sphinx.ext.todo",
@@ -52,12 +53,12 @@ extensions = [
     "sphinx.ext.ifconfig",
     "sphinx.ext.viewcode",
     "sphinx.ext.napoleon",
-    "sphinx.ext.autodoc.typehints",  # still used with autoapi
+    "sphinx_autodoc_typehints",
+    "sphinxcontrib.apidoc",  # automatically generate API docs, see https://github.com/rtfd/readthedocs.org/issues/1139
     "sphinxcontrib.bibtex",
     "nbsphinx",
     "myst_parser",
     "sphinx_design",
-    "autoapi.extension"
 ]
 
 # -- nbsphinx settings -------------------------------------------------------
@@ -77,17 +78,38 @@ for nb_file in nb_files:
 bibtex_bibfiles = ['refs.bib']
 bibtex_default_style = 'unsrtalpha'
 
-# -- Other settings ----------------------------------------------------------
-# autoapi settings
-autoapi_type = 'python'
-autoapi_dirs = ['../../alibi_detect/']
-autoapi_root = 'api'  # rename api directory from 'autoapi' to 'api'
-autoapi_add_toctree_entry = False  # Don't add toctree entry as we enter it manually in top-level index.rst
-autoapi_keep_files = True  # Keep api files after building api docs as we ref to them elsewhere in docs
-autoapi_ignore = ["**/test_*"]  # Don't document tests in api docs
-autoapi_options = ['members', 'show-inheritance', 'imported-members', 'undoc-members']
-autoapi_python_class_content = 'both'
-autodoc_typehints = 'description'
+# apidoc settings
+apidoc_module_dir = "../../alibi_detect"
+apidoc_output_dir = "api"
+apidoc_excluded_paths = ["**/*test*"]
+apidoc_module_first = True
+apidoc_separate_modules = True
+apidoc_extra_args = ["-d 6"]
+
+# mock imports
+autodoc_mock_imports = [
+    "pandas",
+    "sklearn",
+    "skimage",
+    "requests",
+    "cv2",
+    "bs4",
+    "keras",
+    "seaborn",
+    "PIL",
+    "tensorflow",
+    "spacy",
+    "numpy",
+    "tensorflow_probability",
+    "scipy",
+    "matplotlib",
+    "fbprophet",
+    "torch",
+    "transformers",
+    "tqdm",
+    "dill",
+    "numba"
+]
 
 # Napoleon settings
 napoleon_google_docstring = False
@@ -301,4 +323,17 @@ myst_enable_extensions = [
 
 # Create heading anchors for h1 to h3 (useful for local toc's)
 myst_heading_anchors = 3
+
+# Below code fixes a problem with sphinx>=3.2.0 processing functions with
+# torch.jit.script decorator. Probably occuring because torch is being mocked
+# (see https://github.com/sphinx-doc/sphinx/issues/6709).
+def call_mock(self, *args, **kw):
+    from types import FunctionType, MethodType
+    if args and type(args[0]) in [type, FunctionType, MethodType]:
+        # Appears to be a decorator, pass through unchanged
+        return args[0]
+    return self
+
+from sphinx.ext.autodoc.mock import _MockObject
+_MockObject.__call__ = call_mock
 

--- a/doc/source/datasets/overview.ipynb
+++ b/doc/source/datasets/overview.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[source](../api/alibi_detect/datasets/index.rst)"
+    "[source](../api/alibi_detect.datasets.rst)"
    ]
   },
   {
@@ -80,7 +80,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -94,7 +94,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.11"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/doc/source/examples/cd_context_20newsgroup.ipynb
+++ b/doc/source/examples/cd_context_20newsgroup.ipynb
@@ -1525,7 +1525,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.11"
+   "version": "3.7.10"
   }
  },
  "nbformat": 4,

--- a/doc/source/index.md
+++ b/doc/source/index.md
@@ -67,7 +67,7 @@ models/overview
 :caption: API reference
 :maxdepth: 1
 
-API reference <api/alibi_detect/index>
+API reference <api/modules>
 ```
 
 ```{toctree}

--- a/doc/source/models/overview.ipynb
+++ b/doc/source/models/overview.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[source](../api/alibi_detect/models/index.rst)"
+    "[source](../api/alibi_detect.models.rst)"
    ]
   },
   {
@@ -35,7 +35,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -49,7 +49,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.11"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/doc/source/od/methods/ae.ipynb
+++ b/doc/source/od/methods/ae.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[source](../../api/alibi_detect/od/ae/index.rst)"
+    "[source](../../api/alibi_detect.od.ae.rst)"
    ]
   },
   {
@@ -158,7 +158,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -172,7 +172,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.11"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/doc/source/od/methods/aegmm.ipynb
+++ b/doc/source/od/methods/aegmm.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[source](../../api/alibi_detect/od/aegmm/index.rst)"
+    "[source](../../api/alibi_detect.od.aegmm.rst)"
    ]
   },
   {
@@ -178,7 +178,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -192,7 +192,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.11"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/doc/source/od/methods/iforest.ipynb
+++ b/doc/source/od/methods/iforest.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[source](../../api/alibi_detect/od/isolationforest/index.rst)"
+    "[source](../../api/alibi_detect.od.isolationforest.rst)"
    ]
   },
   {
@@ -124,7 +124,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -138,7 +138,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.11"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/doc/source/od/methods/llr.ipynb
+++ b/doc/source/od/methods/llr.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[source](../../api/alibi_detect/od/llr/index.rst)"
+    "[source](../../api/alibi_detect.od.llr.rst)"
    ]
   },
   {
@@ -144,7 +144,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -158,7 +158,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.11"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/doc/source/od/methods/mahalanobis.ipynb
+++ b/doc/source/od/methods/mahalanobis.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[source](../../api/alibi_detect/od/mahalanobis/index.rst)"
+    "[source](../../api/alibi_detect.od.mahalanobis.rst)"
    ]
   },
   {
@@ -148,7 +148,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -162,7 +162,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.11"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/doc/source/od/methods/prophet.ipynb
+++ b/doc/source/od/methods/prophet.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[source](../../api/alibi_detect/od/prophet/index.rst)"
+    "[source](../../api/alibi_detect.od.prophet.rst)"
    ]
   },
   {
@@ -142,7 +142,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -156,7 +156,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.11"
+   "version": "3.9.9"
   }
  },
  "nbformat": 4,

--- a/doc/source/od/methods/seq2seq.ipynb
+++ b/doc/source/od/methods/seq2seq.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[source](../../api/alibi_detect/od/seq2seq/index.rst)"
+    "[source](../../api/alibi_detect.od.seq2seq.rst)"
    ]
   },
   {
@@ -165,7 +165,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -179,7 +179,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.11"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/doc/source/od/methods/sr.ipynb
+++ b/doc/source/od/methods/sr.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[source](../../api/alibi_detect/od/sr/index.rst)"
+    "[source](../../api/alibi_detect.od.sr.rst)"
    ]
   },
   {
@@ -131,7 +131,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -145,7 +145,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.11"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/doc/source/od/methods/vae.ipynb
+++ b/doc/source/od/methods/vae.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[source](../../api/alibi_detect/od/vae/index.rst)"
+    "[source](../../api/alibi_detect.od.vae.rst)"
    ]
   },
   {
@@ -200,7 +200,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.11"
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,

--- a/doc/source/od/methods/vaegmm.ipynb
+++ b/doc/source/od/methods/vaegmm.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[source](../../api/alibi_detect/od/vaegmm/index.rst)"
+    "[source](../../api/alibi_detect.od.vaegmm.rst)"
    ]
   },
   {
@@ -190,7 +190,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -204,7 +204,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.11"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,8 +1,8 @@
 # dependencies for building docs, separate from dev.txt as this is also used for builds on readthedocs.org
 # core dependencies
 sphinx>=4.2.0, <5.0.0
-sphinx-autodoc-typehints>=1.12.0, <=2.0.0
-sphinx-rtd-theme>=1.0.0, <=2.0.0
+sphinx-autodoc-typehints>=1.12.0, <2.0.0
+sphinx-rtd-theme>=1.0.0, <2.0.0
 sphinxcontrib-apidoc>=0.3.0, <0.4.0
 sphinxcontrib-bibtex>=2.1.0, <3.0.0
 myst-parser>=0.14, <0.18

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,9 +1,9 @@
 # dependencies for building docs, separate from dev.txt as this is also used for builds on readthedocs.org
 # core dependencies
 sphinx>=4.2.0, <5.0.0
-sphinx-autodoc-typehints>=1.12.0, <2.0.0
-sphinx-autoapi>=1.8.0, <2.0.0
-sphinx-rtd-theme>=1.0.0, <2.0.0
+sphinx-autodoc-typehints>=1.12.0, <=2.0.0
+sphinx-rtd-theme>=1.0.0, <=2.0.0
+sphinxcontrib-apidoc>=0.3.0, <0.4.0
 sphinxcontrib-bibtex>=2.1.0, <3.0.0
 myst-parser>=0.14, <0.18
 nbsphinx>=0.8.5, <0.9.0


### PR DESCRIPTION
This reverts commit bd0fa0051a7ce8b836a7b33bce0cec33c5443d4f. The move to sphinx autoapi (#482) has caused a few problems; for all classes autoapi automatically includes the docstring of any super class if they can be discovered (i.e. if their packages are installed at build time). For example, see the api doc for [alibi_detect.base.NumpyEncoder](https://seldon--482.org.readthedocs.build/projects/alibi-detect/en/482/api/alibi_detect/base/index.html#alibi_detect.base.NumpyEncoder):

![image](https://user-images.githubusercontent.com/32061685/167028337-05406177-7376-4373-997d-7329c9d9bec1.png)

It has included the entire docstring for [json.JSONEncoder](https://docs.python.org/3/library/json.html#json.JSONEncoder). Since there isn't currently a way to turn off this docstring inheritance, and compatibility with some `sphinx` versions has proved to be flaky, this PR reverts back to `autodoc` and `sphinx-apidoc` for now. Moving to `sphinx-autoapi` was also to aid building of the new `pydantic` api docs in #469, but tweaking which modules are mocked and moving to Python 3.9 on docker seems to have resolved the majority of issues here (see #497).

**Note**: A small number of changes to links in `cd/background.md` have been retained, as these match the (IMO nicer) directive format mentioned in [CONTRIBUTING.md](https://github.com/SeldonIO/alibi/blob/master/CONTRIBUTING.md).