### PR TITLE
Install alibi-detect during RTD docs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -25,5 +25,3 @@ python:
     - requirements: requirements/docs.txt
     - method: pip
       path: .
-      extra_requirements:
-        - torch

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,13 +13,17 @@ build:
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
-   configuration: doc/source/conf.py
+  configuration: doc/source/conf.py
 
 # Optionally build your docs in additional formats such as PDF
 formats:
-   - pdf
+  - pdf
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-   install:
-   - requirements: requirements/docs.txt
+  install:
+    - requirements: requirements/docs.txt
+    - method: pip
+      path: .
+      extra_requirements:
+        - torch

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,10 +5,11 @@
 # Required
 version: 2
 
+# Set the version of Python and other tools you might need
 build:
-  image: latest # Python 3.8 available on latest
-  apt_packages:
-    - pandoc
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
@@ -20,6 +21,5 @@ formats:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-   version: 3.8
    install:
    - requirements: requirements/docs.txt

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -88,27 +88,9 @@ apidoc_extra_args = ["-d 6"]
 
 # mock imports
 autodoc_mock_imports = [
-    "pandas",
     "sklearn",
-    "skimage",
-    "requests",
-    "cv2",
-    "bs4",
-    "keras",
-    "seaborn",
-    "PIL",
-    "tensorflow",
-    "spacy",
-    "numpy",
-    "tensorflow_probability",
-    "scipy",
-    "matplotlib",
     "fbprophet",
     "torch",
-    "transformers",
-    "tqdm",
-    "dill",
-    "numba"
 ]
 
 # Napoleon settings


### PR DESCRIPTION
With the ReadTheDocs V2 config file it appears we can install `alibi-detect` (and its dependencies) as part of the docs build, so that they don't have to be mocked. This is a bit of a waste of compute whilst we have heavy core deps like `tensorflow`, but once the optional deps project is complete we can investigate installing `alibi-detect` on RTD and only mocking heavy optional deps (e.g. `tensorflow`, `torch`). This would ease pain points experienced when building the API docs involving some mocked modules such as `pydantic`. 

Opening this PR now to come back to once the optional deps project is complete.

If going ahead with this we'd likely have to configure `:inherited-members:` to prevent docstrings of inherited modules being included when we don't want them to e.g. see example [here](https://seldon--499.org.readthedocs.build/projects/alibi-detect/en/499/api/alibi_detect.models.tensorflow.html#alibi_detect.models.tensorflow.AE). 