### PR TITLE
Skip ad_ae_cifar10.ipynb notebook in CI

### DIFF
--- a/testing/test_notebooks.py
+++ b/testing/test_notebooks.py
@@ -44,6 +44,8 @@ EXCLUDE_NOTEBOOKS = {
     'cd_text_amazon.ipynb',
     # the following require complex dependencies
     'cd_mol.ipynb',  # complex to install pytorch-geometric
+    # the following require remote artefacts to be updated
+    'ad_ae_cifar10.ipynb',  # bad marshal data error when fetching cifar10-resnet56 model
 }
 if not PROPHET_INSTALLED:
     EXCLUDE_NOTEBOOKS.add('od_prophet_weather.ipynb')  # Exclude if fbprophet not installed i.e. on Windows


### PR DESCRIPTION
Skipping the `ad_ae_cifar10.ipynb` notebook since it currently fails with the error `ValueError: bad marshal data (unknown type code)` when trying to fetch the cifar10 resnet56 artefact. 

This error should be resolved by #336 and #323.