### PR TITLE
Minor fixes for config driven detectors

### DIFF
--- a/alibi_detect/cd/pytorch/context_aware.py
+++ b/alibi_detect/cd/pytorch/context_aware.py
@@ -239,8 +239,8 @@ class ContextMMDDriftTorch(BaseContextMMDDrift):
         K, L = K[perm][:, perm], L[perm][:, perm]
         losses = torch.zeros_like(lams, dtype=torch.float).to(K.device)
         for fold in range(n_folds):
-            inds_oof = np.arange(n)[(fold*fold_size):((fold+1)*fold_size)]
-            inds_if = np.setdiff1d(np.arange(n), inds_oof)
+            inds_oof = list(np.arange(n)[(fold*fold_size):((fold+1)*fold_size)])
+            inds_if = list(np.setdiff1d(np.arange(n), inds_oof))
             K_if, L_if = K[inds_if][:, inds_if], L[inds_if][:, inds_if]
             n_if = len(K_if)
             L_inv_lams = torch.stack(

--- a/alibi_detect/cd/sklearn/classifier.py
+++ b/alibi_detect/cd/sklearn/classifier.py
@@ -32,6 +32,7 @@ class ClassifierDriftSklearn(BaseClassifierDrift):
             use_calibration: bool = False,
             calibration_kwargs: Optional[dict] = None,
             use_oob: bool = False,
+            input_shape: Optional[tuple] = None,
             data_type: Optional[str] = None,
     ) -> None:
         """
@@ -86,6 +87,8 @@ class ClassifierDriftSklearn(BaseClassifierDrift):
             for more details.
         use_oob
             Whether to use out-of-bag(OOB) predictions. Supported only for `RandomForestClassifier`.
+        input_shape
+            Shape of input data.
         data_type
             Optionally specify the data type (tabular, image or time-series). Added to metadata.
         """
@@ -102,6 +105,7 @@ class ClassifierDriftSklearn(BaseClassifierDrift):
             n_folds=n_folds,
             retrain_from_scratch=retrain_from_scratch,
             seed=seed,
+            input_shape=input_shape,
             data_type=data_type
         )
 

--- a/alibi_detect/saving/saving.py
+++ b/alibi_detect/saving/saving.py
@@ -52,11 +52,8 @@ def save_detector(detector: Detector, filepath: Union[str, os.PathLike], legacy:
     if detector_name not in [detector.__name__ for detector in Detector.__args__]:  # type: ignore[attr-defined]
         raise NotImplementedError(f'{detector_name} is not supported by `save_detector`.')
 
-    # Get a list of all existing files in `filepath` (so we know what not to cleanup if an error occurs)
-    filepath = Path(filepath)
-    orig_files = set(filepath.iterdir())
-
     # Saving is wrapped in a try, with cleanup in except. To prevent a half-saved detector remaining upon error.
+    filepath = Path(filepath)
     try:
         # Create directory if it doesn't exist
         if not filepath.is_dir():
@@ -72,6 +69,8 @@ def save_detector(detector: Detector, filepath: Union[str, os.PathLike], legacy:
             save_detector_legacy(detector, filepath)
 
     except Exception as error:
+        # Get a list of all existing files in `filepath` (so we know what not to cleanup if an error occurs)
+        orig_files = set(filepath.iterdir())
         _cleanup_filepath(orig_files, filepath)
         raise RuntimeError(f'Saving failed. The save directory {filepath} has been cleaned.') from error
 

--- a/alibi_detect/utils/_types.py
+++ b/alibi_detect/utils/_types.py
@@ -18,7 +18,7 @@ else:
 # TODO - above repo also has some very clever functionality to allow passing the numpy array as a npy/npz file.
 #  This could be useful to explore in order to simplify our loading submodule.
 T = TypeVar("T", bound=np.generic)
-if NumpyVersion(np.__version__) < "1.22.0":
+if NumpyVersion(np.__version__) < "1.22.0" or sys.version_info < (3, 9):
     class NDArray(Generic[T], np.ndarray):
         """
         A Generic pydantic model to validate (and coerce) np.ndarray's.


### PR DESCRIPTION
This PR fixes a number of issues uncovered in final testing:

- `input_shape` kwarg missing from `ClassifierDriftSklearn`. Discovered by notebook tests as relevent test missing from CI (see #518).
- Issue with `save_detector` in legacy mode when save directory not already created.
- Issue with `NDArray` not working on Python<3.9 with v. new NumPy (`1.22.4`) installed.