### PR TITLE
Fix for ContextMMDDriftTorch typing issue with numpy >=1.22

### DIFF
--- a/alibi_detect/cd/pytorch/context_aware.py
+++ b/alibi_detect/cd/pytorch/context_aware.py
@@ -230,8 +230,8 @@ class ContextMMDDriftTorch(BaseContextMMDDrift):
         K, L = K[perm][:, perm], L[perm][:, perm]
         losses = torch.zeros_like(lams, dtype=torch.float).to(K.device)
         for fold in range(n_folds):
-            inds_oof = np.arange(n)[(fold*fold_size):((fold+1)*fold_size)]
-            inds_if = np.setdiff1d(np.arange(n), inds_oof)
+            inds_oof = list(np.arange(n)[(fold*fold_size):((fold+1)*fold_size)])
+            inds_if = list(np.setdiff1d(np.arange(n), inds_oof))
             K_if, L_if = K[inds_if][:, inds_if], L[inds_if][:, inds_if]
             n_if = len(K_if)
             L_inv_lams = torch.stack(

--- a/doc/source/cd/methods/contextmmddrift.ipynb
+++ b/doc/source/cd/methods/contextmmddrift.ipynb
@@ -26,7 +26,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Usage\n",
     "\n",

--- a/doc/source/cd/methods/contextmmddrift.ipynb
+++ b/doc/source/cd/methods/contextmmddrift.ipynb
@@ -26,11 +26,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "## Usage\n",
     "\n",


### PR DESCRIPTION
With the release of `numba 0.55.2` (https://github.com/numba/numba/blob/0.55.2/CHANGE_LOG) `numpy 1.22` is now installable. With this NumPy version `mypy` fails in `ContextMMDDriftTorch`. This PR fixes the issue by ensuring the `torch.Tensor`'s are indexed by `list`'s not `np.ndarray`'s. 