### PR TITLE
Feature Optional prophet

### DIFF
--- a/alibi_detect/cd/pytorch/mmd.py
+++ b/alibi_detect/cd/pytorch/mmd.py
@@ -126,7 +126,8 @@ class MMDDriftTorch(BaseMMDDrift):
         x_ref = torch.from_numpy(x_ref).to(self.device)  # type: ignore[assignment]
         x = torch.from_numpy(x).to(self.device)  # type: ignore[assignment]
         # compute kernel matrix, MMD^2 and apply permutation test using the kernel matrix
-        n = x.shape[0]
+        # TODO: (See https://github.com/SeldonIO/alibi-detect/issues/540)
+        n = x.shape[0]  # type: ignore
         kernel_mat = self.kernel_matrix(x_ref, x)  # type: ignore[arg-type]
         kernel_mat = kernel_mat - torch.diag(kernel_mat.diag())  # zero diagonal
         mmd2 = mmd2_from_kernel_matrix(kernel_mat, n, permute=False, zero_diag=False)

--- a/alibi_detect/od/__init__.py
+++ b/alibi_detect/od/__init__.py
@@ -2,7 +2,6 @@ from alibi_detect.utils.missing_optional_dependency import import_optional
 
 from .isolationforest import IForest
 from .mahalanobis import Mahalanobis
-from .prophet import OutlierProphet
 from .sr import SpectralResidual
 
 OutlierAEGMM = import_optional('alibi_detect.od.aegmm', names=['OutlierAEGMM'])

--- a/alibi_detect/od/__init__.py
+++ b/alibi_detect/od/__init__.py
@@ -2,7 +2,7 @@ from alibi_detect.utils.missing_optional_dependency import import_optional
 
 from .isolationforest import IForest
 from .mahalanobis import Mahalanobis
-from .prophet import PROPHET_INSTALLED, OutlierProphet
+from .prophet import OutlierProphet
 from .sr import SpectralResidual
 
 OutlierAEGMM = import_optional('alibi_detect.od.aegmm', names=['OutlierAEGMM'])
@@ -11,6 +11,7 @@ OutlierVAE = import_optional('alibi_detect.od.vae', names=['OutlierVAE'])
 OutlierVAEGMM = import_optional('alibi_detect.od.vaegmm', names=['OutlierVAEGMM'])
 OutlierSeq2Seq = import_optional('alibi_detect.od.seq2seq', names=['OutlierSeq2Seq'])
 LLR = import_optional('alibi_detect.od.llr', names=['LLR'])
+OutlierProphet = import_optional('alibi_detect.od.prophet', names=['OutlierProphet'])
 
 __all__ = [
     "OutlierAEGMM",
@@ -21,8 +22,6 @@ __all__ = [
     "OutlierVAEGMM",
     "OutlierSeq2Seq",
     "SpectralResidual",
-    "LLR"
+    "LLR",
+    "OutlierProphet"
 ]
-
-if PROPHET_INSTALLED:
-    __all__ += ["OutlierProphet"]

--- a/alibi_detect/od/prophet.py
+++ b/alibi_detect/od/prophet.py
@@ -1,10 +1,4 @@
-try:
-    from fbprophet import Prophet
-
-    PROPHET_INSTALLED = True
-except ImportError:
-    PROPHET_INSTALLED = False
-
+from fbprophet import Prophet
 import logging
 import pandas as pd
 from typing import Dict, List, Union

--- a/alibi_detect/od/tests/test_prophet.py
+++ b/alibi_detect/od/tests/test_prophet.py
@@ -33,7 +33,7 @@ def prophet_params(request):
 
 @pytest.mark.parametrize('prophet_params', list(range(n_tests)), indirect=True)
 def test_prophet(prophet_params):
-    fbprophet = pytest.importorskip('fbprophet', "Prophet tests skipped as Prophet not installed")
+    fbprophet = pytest.importorskip('fbprophet', reason="Prophet tests skipped as Prophet not installed")
     growth, return_instance_score, return_forecast = prophet_params
     od = OutlierProphet(growth=growth)
     assert isinstance(od.model, fbprophet.forecaster.Prophet)

--- a/alibi_detect/od/tests/test_prophet.py
+++ b/alibi_detect/od/tests/test_prophet.py
@@ -4,7 +4,6 @@ import numpy as np
 import pandas as pd
 import pytest
 from alibi_detect.od import OutlierProphet
-from alibi_detect.od.prophet import PROPHET_INSTALLED
 from alibi_detect.version import __version__
 
 growth = ['linear', 'logistic']
@@ -32,11 +31,9 @@ def prophet_params(request):
     return tests[request.param]
 
 
-@pytest.mark.skipif(not PROPHET_INSTALLED,
-                    reason="Prophet tests skipped as Prophet not installed")
 @pytest.mark.parametrize('prophet_params', list(range(n_tests)), indirect=True)
 def test_prophet(prophet_params):
-    import fbprophet
+    fbprophet = pytest.importorskip('fbprophet', "Prophet tests skipped as Prophet not installed")
     growth, return_instance_score, return_forecast = prophet_params
     od = OutlierProphet(growth=growth)
     assert isinstance(od.model, fbprophet.forecaster.Prophet)

--- a/alibi_detect/saving/tensorflow/_saving.py
+++ b/alibi_detect/saving/tensorflow/_saving.py
@@ -21,6 +21,7 @@ from alibi_detect.od import (LLR, IForest, Mahalanobis, OutlierAE,
                              OutlierVAE, OutlierVAEGMM, SpectralResidual)
 from alibi_detect.utils._types import Literal
 from alibi_detect.utils.tensorflow.kernels import GaussianRBF
+from alibi_detect.utils.missing_optional_dependency import MissingDependency
 
 logger = logging.getLogger(__name__)
 
@@ -215,7 +216,7 @@ def save_detector_legacy(detector, filepath):
         state_dict = state_adv_ae(detector)
     elif isinstance(detector, ModelDistillation):
         state_dict = state_adv_md(detector)
-    elif isinstance(detector, OutlierProphet):
+    elif not isinstance(OutlierProphet, MissingDependency) and isinstance(detector, OutlierProphet):
         state_dict = state_prophet(detector)
     elif isinstance(detector, SpectralResidual):
         state_dict = state_sr(detector)

--- a/alibi_detect/tests/test_dep_management.py
+++ b/alibi_detect/tests/test_dep_management.py
@@ -115,6 +115,7 @@ def test_od_dependencies(opt_dep):
             ('OutlierAE', ['tensorflow']),
             ('OutlierAEGMM', ['tensorflow']),
             ('OutlierSeq2Seq', ['tensorflow']),
+            ("OutlierProphet", ['prophet'])
             ]:
         dependency_map[dependency] = relations
     from alibi_detect import od

--- a/alibi_detect/utils/tests/test_saving_legacy.py
+++ b/alibi_detect/utils/tests/test_saving_legacy.py
@@ -2,6 +2,7 @@
 Tests for saving/loading of detectors with legacy .dill state_dict. As legacy save/load functionality becomes
 deprecated, these tests will be removed, and more tests will be added to test_savin.py.
 """
+from alibi_detect.utils.missing_optional_dependency import MissingDependency
 from functools import partial
 import numpy as np
 import pytest
@@ -16,7 +17,6 @@ from alibi_detect.cd.tensorflow import UAE, preprocess_drift
 from alibi_detect.models.tensorflow.autoencoder import DecoderLSTM, EncoderLSTM
 from alibi_detect.od import (IForest, LLR, Mahalanobis, OutlierAEGMM, OutlierVAE, OutlierVAEGMM,
                              OutlierProphet, SpectralResidual, OutlierSeq2Seq, OutlierAE)
-from alibi_detect.od.prophet import PROPHET_INSTALLED
 from alibi_detect.saving import save_detector, load_detector
 
 input_dim = 4
@@ -133,7 +133,8 @@ detector = [
                     n_folds=n_folds_drift,
                     train_size=None)
 ]
-if PROPHET_INSTALLED:
+
+if not isinstance(OutlierProphet, MissingDependency):
     detector.append(
             OutlierProphet(threshold=.7,
                            growth='logistic')

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ envlist=
     default
     tensorflow
     torch
-;    prophet
+    prophet
 ;    all
 
 # tox test environment for generating licenses

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ envlist=
     tensorflow
     torch
     prophet
-;    all
+    all
 
 # tox test environment for generating licenses
 [testenv:licenses]


### PR DESCRIPTION
# Todo:
- [x] Tox env tests
- [ ] There is at least one fix in #553 that are needed here in order for tox tests to pass :face_exhaling: namely: tox env needs pytest-randomly dependency
___

## What is this

This work branches off [`feature/dep-management`](https://github.com/SeldonIO/alibi-detect/pull/501) and will make `prophet` optional dependency of `alibi-detect`.

___

### What this PR doesn't include:

1. The install options in the docs. I think it makes sense to do this in a later PR on the feature branch for all the optional deps all at once, once this branch has been merged in.
2. The install options in the `README.md` for same reason as 1.
3. The config-driven work in the [release branch](https://github.com/SeldonIO/alibi-detect/tree/release/0.10.0). This will be done in a separate PR in order to manage Release/Master branch complexity issues.
4. Make Licenses updates. This will be done in a PR on the feature branch.

___