### PR TITLE
Feature Optional dependencies documentation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,13 +69,11 @@ The package, `alibi-detect` can be installed from:
 ### With pip
 
 - alibi-detect can be installed from [PyPI](https://pypi.org/project/alibi-detect):
-
    ```bash
    pip install alibi-detect
    ```
    
 - Alternatively, the development version can be installed:
-
    ```bash
    pip install git+https://github.com/SeldonIO/alibi-detect.git
    ```
@@ -83,11 +81,6 @@ The package, `alibi-detect` can be installed from:
 - To install with the tensorflow backend:
   ```bash
   pip install alibi-detect[tensorflow]
-  ```
-  
-- To install with tensorflow-probability:
-  ```bash
-  pip install alibi-detect[tensorflow_probability]
   ```
 
 - To install with the PyTorch backend:
@@ -116,17 +109,12 @@ which can be installed to the *base* conda enviroment with:
 conda install mamba -n base -c conda-forge
 ```
 
-- To install alibi-detect with the default TensorFlow backend:
+To install alibi-detect:
 
-  ```bash
-  mamba install -c conda-forge alibi-detect
-  ```
+```bash
+mamba install -c conda-forge alibi-detect
+```
 
-- To install with the PyTorch backend:
-
-  ```bash
-  mamba install -c conda-forge alibi-detect pytorch
-  ```
 
 ### Usage
 We will use the [VAE outlier detector](https://docs.seldon.io/projects/alibi-detect/en/stable/od/methods/vae.html) to illustrate the API.

--- a/README.md
+++ b/README.md
@@ -94,11 +94,6 @@ The package, `alibi-detect` can be installed from:
    pip install alibi-detect[prophet]
    ```
 
-- To use the `CVMDriftOnline` or `FetDriftOnline` drift detectors install with Numba:
-   ```bash
-   pip install alibi-detect[numba]
-   ```
-
 
 ### With conda
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,17 @@ The package, `alibi-detect` can be installed from:
    pip install git+https://github.com/SeldonIO/alibi-detect.git
    ```
 
-- To install with the PyTorch backend (in addition to the default TensorFlow backend):
+- To install with the tensorflow backend:
+  ```bash
+  pip install alibi-detect[tensorflow]
+  ```
+  
+- To install with tensorflow-probability:
+  ```bash
+  pip install alibi-detect[tensorflow_probability]
+  ```
+
+- To install with the PyTorch backend:
   ```bash
   pip install alibi-detect[torch]
   ```
@@ -90,6 +100,12 @@ The package, `alibi-detect` can be installed from:
    ```bash
    pip install alibi-detect[prophet]
    ```
+
+- To use the `CVMDriftOnline` or `FetDriftOnline` drift detectors install with Numba:
+   ```bash
+   pip install alibi-detect[numba]
+   ```
+
 
 ### With conda
 
@@ -181,8 +197,8 @@ The following tables show the advised use cases for each algorithm. The column *
 
 #### TensorFlow and PyTorch support
 
-The drift detectors support TensorFlow and PyTorch backends. Alibi Detect does however not install PyTorch for you. 
-Check the [PyTorch docs](https://pytorch.org/) how to do this. Example:
+The drift detectors support TensorFlow and PyTorch backends. Alibi Detect does not install these as default. See the 
+[installation options](#installation-and-usage) for more details
 
 ```python
 from alibi_detect.cd import MMDDrift

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ The following tables show the advised use cases for each algorithm. The column *
 #### TensorFlow and PyTorch support
 
 The drift detectors support TensorFlow and PyTorch backends. Alibi Detect does not install these as default. See the 
-[installation options](#installation-and-usage) for more details
+[installation options](#installation-and-usage) for more details.
 
 ```python
 from alibi_detect.cd import MMDDrift

--- a/doc/source/overview/getting_started.md
+++ b/doc/source/overview/getting_started.md
@@ -9,7 +9,23 @@ by following the instructions below.
 ``````{dropdown} Install via PyPI
 
 ```{div} sd-mb-3
-- Alibi Detect can be installed from [PyPI](https://pypi.org/project/alibi-detect/) with `pip`:
+Alibi Detect can be installed from [PyPI](https://pypi.org/project/alibi-detect/) with `pip`. We provide optional 
+dependencies for a number of modules that are large or sometimes tricky to install. Many detectors are supported out 
+the box with the default install but some detectors require a specific optional dependency installation in order to 
+use. For instance the OutlierProphet detector requires the prophet installation in order to use. Other detectors have 
+a choice of backend. For instance the LSDDDrift detector has a choice of tensorflow or pytorch backends. The tabs 
+bellow list the full set of detector functionality provided by each optional dependency. If your unsure, or wish to 
+have access to as many as possible the recomended installation is:
+```
+
+```bash
+pip install alibi-detect[tensorflow,tensorflow-probability,numba,prophet]
+```
+
+or 
+
+```bash
+pip install alibi-detect[torch,numba,prophet]
 ```
 
 `````{tab-set}
@@ -19,11 +35,22 @@ by following the instructions below.
 :class-label: sd-pt-0
 
 ```{div} sd-mb-1
-Installation with default [TensorFlow](https://www.tensorflow.org/) backend.
+Default installation.
 ```
 
 ```bash
 pip install alibi-detect
+```
+
+```{div} sd-mb-1
+The default installation provides out the box support for the following detectors:
+- ChiSquareDrift
+- CVMDrift
+- FetDrift
+- KSDrift
+- TabularDrift
+- Mahanobis
+- SpectralResidual
 ```
 ````
 
@@ -32,11 +59,23 @@ pip install alibi-detect
 :class-label: sd-pt-0
 
 ```{div} sd-mb-1
-Installation with [TensorFlow](https://www.tensorflow.org/) and [PyTorch](https://pytorch.org/) backends.
+Installation with [PyTorch](https://pytorch.org/) backend.
 ```
 
 ```bash
 pip install alibi-detect[torch]
+```
+
+```{div} sd-mb-1
+The PyTorch installation is required to use the PyTorch backend for the following detectors
+- ClassifierDrift
+- LearnedKernelDrift
+- LSDDDrift
+- LSDDDriftOnline
+- MMDDrift
+- MMDDriftOnline
+- SpotTheDiffDrift
+- ContextMMDDrfit
 ```
 
 ```{note}
@@ -45,15 +84,108 @@ prior to installing alibi-detect.
 ```
 ````
 
+````{tab-item} TensorFlow
+:sync: label-tensorflow
+:class-label: sd-pt-0
+
+```{div} sd-mb-1
+Installation with [TensorFlow](https://www.tensorflow.org/) backend.
+```
+
+```bash
+pip install alibi-detect[tensorflow]
+```
+
+```{div} sd-mb-1
+The TensorFlow installation is required to use the TensorFlow backend for the following detectors
+- LearnedKernelDrift
+- LSDDDrift
+- LSDDDriftOnline
+- MMDDrift
+- MMDDriftOnline
+- SpotTheDiffDrift
+- ContextMMDDrfit
+
+The TensorFlow installation is **required** to use the following detectors
+- OutlinerAE
+```
+
+````
+
+````{tab-item} TensorFlow-Probability
+:sync: label-tensorflow-probability
+:class-label: sd-pt-0
+
+```{div} sd-mb-1
+Installation with [TensorFlow Probability](https://www.tensorflow.org/probability).
+```
+
+```bash
+pip install alibi-detect[tensorflow_probability]
+```
+
+```{div} sd-mb-1
+The TensorFlow and Tensorflow-Probability installations are required to use the TensorFlow backend for the following 
+detectors
+- ClassifierDrift
+
+The TensorFlow and Tensorflow-Probability installations are **required** to use the following detectors
+- OutlinerAEGMM
+- LLR
+- OutlierSeq2Seq
+- OutlierVAE
+- OutlierVAEGMM
+- AdversarialAE
+- ModelDistillation
+```
+````
+
+````{tab-item} Numba
+:sync: label-numba
+:class-label: sd-pt-0
+
+```{div} sd-mb-1
+Installation with [Numba](https://numba.pydata.org/)
+```
+
+```bash
+pip install alibi-detect[numba]
+```
+
+```{div} sd-mb-1
+The Numba installation is **required** to use the following detectors:
+- CVMDriftOnline
+- FETDriftOnline
+```
+````
+
 ````{tab-item} Prophet
 :class-label: sd-pt-0
 
 ```{div} sd-mb-1
-Installation with the [Prophet](../od/methods/prophet.ipynb) time series outlier detector enabled.
+Installation with [Prophet](https://facebook.github.io/prophet/) support.
+
 ```
 
 ```bash
 pip install alibi-detect[prophet]
+```
+
+```{div} sd-mb-1
+Provides support for the [OutlierProphet](../od/methods/prophet.ipynb) time series outlier detector.
+```
+````
+
+````{tab-item} All
+:sync: label-all
+:class-label: sd-pt-0
+
+```{div} sd-mb-1
+Install all optional dependencies.
+```
+
+```bash
+pip install alibi-detect[all]
 ```
 ````
 

--- a/doc/source/overview/getting_started.md
+++ b/doc/source/overview/getting_started.md
@@ -268,8 +268,8 @@ prior to installing alibi-detect.
 [Alibi Detect](https://github.com/SeldonIO/alibi-detect) is an open source Python library focused on 
 **outlier**, **adversarial** and **drift** detection. The package aims to cover both 
 online and offline detectors for tabular data, text, images and time series. 
-Both **TensorFlow** and **PyTorch** backends are supported for drift detection. Alibi Detect does however 
-not install PyTorch for you. Check the [PyTorch docs](https://pytorch.org/) how to do this.
+Both **TensorFlow** and **PyTorch** backends are supported for drift detection. Alibi-Detect does not install these as 
+default. See [installation options](#installation) for more details.
 
 To get a list of respectively the latest outlier, adversarial and drift detection algorithms, you can type:
 

--- a/doc/source/overview/getting_started.md
+++ b/doc/source/overview/getting_started.md
@@ -21,8 +21,8 @@ ___
 
 `````{tab-set}
 
-````{tab-item} Standard
-:sync: label-standard
+````{tab-item} Default
+:sync: label-default
 :class-label: sd-pt-0
 
 ```{div} sd-mb-1
@@ -54,7 +54,7 @@ If you are unsure which detector to use, or wish to have access to as many as po
 ```
 
 ```bash
-pip install alibi-detect[tensorflow,tensorflow-probability,numba,prophet]
+pip install alibi-detect[tensorflow,numba,prophet]
 ```
 
 ```{div} sd-mb-1
@@ -66,7 +66,7 @@ pip install alibi-detect[torch,numba,prophet]
 ```
 
 ```{div} sd-mb-1
-The following detectors do not have `pytorch` backend support:
+However, the following detectors do not have `pytorch` backend support:
 
 - OutlierAE
 - OutlierAEGMM
@@ -85,8 +85,8 @@ pip install alibi-detect[all]
 ```
 
 ```{note}
-If you wish to use the GPU version of PyTorch, or are installing on Windows, it is recommended to [install and test PyTorch](https://pytorch.org/get-started/locally/) 
-prior to installing alibi-detect.
+If you wish to use the GPU version of PyTorch, or are installing on Windows, it is recommended to 
+[install and test PyTorch](https://pytorch.org/get-started/locally/) prior to installing alibi-detect.
 ```
 ````
 
@@ -115,8 +115,8 @@ The PyTorch installation is required to use the PyTorch backend for the followin
 ```
 
 ```{note}
-If you wish to use the GPU version of PyTorch, or are installing on Windows, it is recommended to [install and test PyTorch](https://pytorch.org/get-started/locally/) 
-prior to installing alibi-detect.
+If you wish to use the GPU version of PyTorch, or are installing on Windows, it is recommended to 
+[install and test PyTorch](https://pytorch.org/get-started/locally/) prior to installing alibi-detect.
 ```
 ````
 
@@ -134,6 +134,7 @@ pip install alibi-detect[tensorflow]
 
 ```{div} sd-mb-1
 The TensorFlow installation is required to use the TensorFlow backend for the following detectors
+- ClassifierDrift
 - LearnedKernelDrift
 - LSDDDrift
 - LSDDDriftOnline
@@ -142,30 +143,8 @@ The TensorFlow installation is required to use the TensorFlow backend for the fo
 - SpotTheDiffDrift
 - ContextMMDDrfit
 
-The TensorFlow installation is **required** to use the following detectors
+The TensorFlow installation is required to use the following detectors
 - OutlinerAE
-```
-
-````
-
-````{tab-item} TensorFlow-Probability
-:sync: label-tensorflow-probability
-:class-label: sd-pt-0
-
-```{div} sd-mb-1
-Installation with [TensorFlow Probability](https://www.tensorflow.org/probability).
-```
-
-```bash
-pip install alibi-detect[tensorflow_probability]
-```
-
-```{div} sd-mb-1
-The TensorFlow and Tensorflow-Probability installations are required to use the TensorFlow backend for the following 
-detectors
-- ClassifierDrift
-
-The TensorFlow and Tensorflow-Probability installations are **required** to use the following detectors
 - OutlinerAEGMM
 - LLR
 - OutlierSeq2Seq
@@ -200,7 +179,6 @@ The Numba installation is **required** to use the following detectors:
 
 ```{div} sd-mb-1
 Installation with [Prophet](https://facebook.github.io/prophet/) support.
-
 ```
 
 ```bash
@@ -230,36 +208,9 @@ conda install mamba -n base -c conda-forge
 - `mamba` can then be used to install alibi-detect in a conda enviroment:
 ```
 
-`````{tab-set}
-
-````{tab-item} Standard
-:sync: label-standard
-:class-label: sd-pt-0
-
-Installation with default [TensorFlow](https://www.tensorflow.org/) backend.
-
 ```bash
 mamba install -c conda-forge alibi-detect
 ```
-````
-
-````{tab-item} PyTorch
-:sync: label-torch
-:class-label: sd-pt-0
-
-Installation with [TensorFlow](https://www.tensorflow.org/) and [PyTorch](https://pytorch.org/) backends.
-
-```bash
-mamba install -c conda-forge alibi-detect pytorch
-```
-
-```{note}
-If you wish to use the GPU version of PyTorch, or are installing on Windows, it is recommended to [install and test PyTorch](https://pytorch.org/get-started/locally/) 
-prior to installing alibi-detect.
-```
-````
-
-`````
 ``````
 
 

--- a/doc/source/overview/getting_started.md
+++ b/doc/source/overview/getting_started.md
@@ -168,7 +168,7 @@ pip install alibi-detect[numba]
 ```
 
 ```{div} sd-mb-1
-The Numba installation is **required** to use the following detectors:
+The Numba installation is required to use the following detectors:
 - CVMDriftOnline
 - FETDriftOnline
 ```

--- a/doc/source/overview/getting_started.md
+++ b/doc/source/overview/getting_started.md
@@ -10,23 +10,14 @@ by following the instructions below.
 
 ```{div} sd-mb-3
 Alibi Detect can be installed from [PyPI](https://pypi.org/project/alibi-detect/) with `pip`. We provide optional 
-dependencies for a number of modules that are large or sometimes tricky to install. Many detectors are supported out 
-the box with the default install but some detectors require a specific optional dependency installation in order to 
-use. For instance the OutlierProphet detector requires the prophet installation in order to use. Other detectors have 
-a choice of backend. For instance the LSDDDrift detector has a choice of tensorflow or pytorch backends. The tabs 
-bellow list the full set of detector functionality provided by each optional dependency. If your unsure, or wish to 
-have access to as many as possible the recomended installation is:
+dependency buckets for several modules that are large or sometimes tricky to install. Many detectors are supported out 
+of the box with the default install but some detectors require a specific optional dependency installation to use. For 
+instance, the `OutlierProphet` detector requires the prophet installation. Other detectors have a choice of backend. 
+For instance, the `LSDDDrift` detector has a choice of `tensorflow` or `pytorch` backends. The tabs below list the full
+set of detector functionality provided by each optional dependency. 
 ```
 
-```bash
-pip install alibi-detect[tensorflow,tensorflow-probability,numba,prophet]
-```
-
-or 
-
-```bash
-pip install alibi-detect[torch,numba,prophet]
-```
+___
 
 `````{tab-set}
 
@@ -51,6 +42,51 @@ The default installation provides out the box support for the following detector
 - TabularDrift
 - Mahanobis
 - SpectralResidual
+```
+````
+
+````{tab-item} Recommended
+:sync: label-recommended
+:class-label: sd-pt-0
+
+```{div} sd-mb-1
+If you are unsure which detector to use, or wish to have access to as many as possible the recommended installation is:
+```
+
+```bash
+pip install alibi-detect[tensorflow,tensorflow-probability,numba,prophet]
+```
+
+```{div} sd-mb-1
+If you would rather use `pytorch` backends then you can use:
+```
+
+```bash
+pip install alibi-detect[torch,numba,prophet]
+```
+
+```{div} sd-mb-1
+The following detectors do not have `pytorch` backend support:
+
+- OutlierAE
+- OutlierAEGMM
+- LLR
+- OutlierSeq2Seq
+- OutlierVAE
+- OutlierVAEGMM
+- AdversarialAW
+- ModelDistillation
+
+Alternatively you can install all the dependencies using (this will include both `tensorflow` and `pytorch`):
+```
+
+```bash
+pip install alibi-detect[all]
+```
+
+```{note}
+If you wish to use the GPU version of PyTorch, or are installing on Windows, it is recommended to [install and test PyTorch](https://pytorch.org/get-started/locally/) 
+prior to installing alibi-detect.
 ```
 ````
 
@@ -145,7 +181,7 @@ The TensorFlow and Tensorflow-Probability installations are **required** to use 
 :class-label: sd-pt-0
 
 ```{div} sd-mb-1
-Installation with [Numba](https://numba.pydata.org/)
+Installation with [Numba](https://numba.pydata.org/) support.
 ```
 
 ```bash
@@ -175,20 +211,6 @@ pip install alibi-detect[prophet]
 Provides support for the [OutlierProphet](../od/methods/prophet.ipynb) time series outlier detector.
 ```
 ````
-
-````{tab-item} All
-:sync: label-all
-:class-label: sd-pt-0
-
-```{div} sd-mb-1
-Install all optional dependencies.
-```
-
-```bash
-pip install alibi-detect[all]
-```
-````
-
 `````
 ``````
 

--- a/doc/source/overview/getting_started.md
+++ b/doc/source/overview/getting_started.md
@@ -35,9 +35,9 @@ pip install alibi-detect
 
 ```{div} sd-mb-1
 The default installation provides out the box support for the following detectors:
-- ChiSquareDrift
+- [ChiSquareDrift](../cd/methods/chisquaredrift.ipynb)
 - CVMDrift
-- FetDrift
+- FETDrift
 - KSDrift
 - TabularDrift
 - Mahanobis
@@ -103,7 +103,7 @@ pip install alibi-detect[torch]
 ```
 
 ```{div} sd-mb-1
-The PyTorch installation is required to use the PyTorch backend for the following detectors
+The PyTorch installation is required to use the PyTorch backend for the following detectors:
 - ClassifierDrift
 - LearnedKernelDrift
 - LSDDDrift
@@ -111,7 +111,7 @@ The PyTorch installation is required to use the PyTorch backend for the followin
 - MMDDrift
 - MMDDriftOnline
 - SpotTheDiffDrift
-- ContextMMDDrfit
+- ContextMMDDrift
 ```
 
 ```{note}
@@ -133,7 +133,7 @@ pip install alibi-detect[tensorflow]
 ```
 
 ```{div} sd-mb-1
-The TensorFlow installation is required to use the TensorFlow backend for the following detectors
+The TensorFlow installation is required to use the TensorFlow backend for the following detectors:
 - ClassifierDrift
 - LearnedKernelDrift
 - LSDDDrift
@@ -141,11 +141,11 @@ The TensorFlow installation is required to use the TensorFlow backend for the fo
 - MMDDrift
 - MMDDriftOnline
 - SpotTheDiffDrift
-- ContextMMDDrfit
+- ContextMMDDrift
 
-The TensorFlow installation is required to use the following detectors
-- OutlinerAE
-- OutlinerAEGMM
+The TensorFlow installation is required to use the following detectors:
+- OutlierAE
+- OutlierAEGMM
 - LLR
 - OutlierSeq2Seq
 - OutlierVAE
@@ -236,7 +236,7 @@ alibi_detect.od.__all__
  'OutlierAE',
  'OutlierVAE',
  'OutlierVAEGMM',
- 'OutlierProphet',  # requires prophet: pip install alibi-detect[prophet]
+ 'OutlierProphet',
  'OutlierSeq2Seq',
  'SpectralResidual',
  'LLR']

--- a/doc/source/overview/getting_started.md
+++ b/doc/source/overview/getting_started.md
@@ -54,7 +54,7 @@ If you are unsure which detector to use, or wish to have access to as many as po
 ```
 
 ```bash
-pip install alibi-detect[tensorflow,numba,prophet]
+pip install alibi-detect[tensorflow,prophet]
 ```
 
 ```{div} sd-mb-1
@@ -62,7 +62,7 @@ If you would rather use `pytorch` backends then you can use:
 ```
 
 ```bash
-pip install alibi-detect[torch,numba,prophet]
+pip install alibi-detect[torch,prophet]
 ```
 
 ```{div} sd-mb-1
@@ -152,25 +152,6 @@ The TensorFlow installation is required to use the following detectors:
 - [OutlierVAEGMM](../od/methods/vaegmm.ipynb)
 - [AdversarialAE](../ad/methods/adversarialae.ipynb)
 - [ModelDistillation](../ad/methods/modeldistillation.ipynb)
-```
-````
-
-````{tab-item} Numba
-:sync: label-numba
-:class-label: sd-pt-0
-
-```{div} sd-mb-1
-Installation with [Numba](https://numba.pydata.org/) support.
-```
-
-```bash
-pip install alibi-detect[numba]
-```
-
-```{div} sd-mb-1
-The Numba installation is required to use the following detectors:
-- [CVMDriftOnline](../cd/methods/cvmdrift.ipynb)
-- [FETDriftOnline](../cd/methods/fetdrift.ipynb)
 ```
 ````
 

--- a/doc/source/overview/getting_started.md
+++ b/doc/source/overview/getting_started.md
@@ -36,12 +36,12 @@ pip install alibi-detect
 ```{div} sd-mb-1
 The default installation provides out the box support for the following detectors:
 - [ChiSquareDrift](../cd/methods/chisquaredrift.ipynb)
-- CVMDrift
-- FETDrift
-- KSDrift
-- TabularDrift
-- Mahanobis
-- SpectralResidual
+- [CVMDrift](../cd/methods/cvmdrift.ipynb)
+- [FETDrift](../cd/methods/fetdrift.ipynb)
+- [KSDrift](../cd/methods/ksdrift.ipynb)
+- [TabularDrift](../cd/methods/tabulardrift.ipynb)
+- [Mahalanobis](../od/methods/mahalanobis.ipynb)
+- [SpectralResidual](../od/methods/sr.ipynb)
 ```
 ````
 
@@ -68,14 +68,14 @@ pip install alibi-detect[torch,numba,prophet]
 ```{div} sd-mb-1
 However, the following detectors do not have `pytorch` backend support:
 
-- OutlierAE
-- OutlierAEGMM
-- LLR
-- OutlierSeq2Seq
-- OutlierVAE
-- OutlierVAEGMM
-- AdversarialAW
-- ModelDistillation
+- [OutlierAE](../od/methods/ae.ipynb)
+- [OutlierAEGMM](../od/methods/aegmm.ipynb)
+- [LLR](../od/methods/llr.ipynb)
+- [OutlierSeq2Seq](../od/methods/seq2seq.ipynb)
+- [OutlierVAE](../od/methods/vae.ipynb)
+- [OutlierVAEGMM](../od/methods/vaegmm.ipynb)
+- [AdversarialAE](../ad/methods/adversarialae.ipynb)
+- [ModelDistillation](../ad/methods/modeldistillation.ipynb)
 
 Alternatively you can install all the dependencies using (this will include both `tensorflow` and `pytorch`):
 ```
@@ -104,14 +104,14 @@ pip install alibi-detect[torch]
 
 ```{div} sd-mb-1
 The PyTorch installation is required to use the PyTorch backend for the following detectors:
-- ClassifierDrift
-- LearnedKernelDrift
-- LSDDDrift
-- LSDDDriftOnline
-- MMDDrift
-- MMDDriftOnline
-- SpotTheDiffDrift
-- ContextMMDDrift
+- [ClassifierDrift](../cd/methods/classifierdrift.ipynb)
+- [LearnedKernelDrift](../cd/methods/learnedkerneldrift.ipynb)
+- [LSDDDrift](../cd/methods/lsdddrift.ipynb)
+- [LSDDDriftOnline](../cd/methods/onlinelsdddrift.ipynb)
+- [MMDDrift](../cd/methods/mmddrift.ipynb)
+- [MMDDriftOnline](../cd/methods/onlinemmddrift.ipynb)
+- [SpotTheDiffDrift](../cd/methods/spotthediffdrift.ipynb)
+- [ContextMMDDrift](../cd/methods/contextmmddrift.ipynb)
 ```
 
 ```{note}
@@ -134,24 +134,24 @@ pip install alibi-detect[tensorflow]
 
 ```{div} sd-mb-1
 The TensorFlow installation is required to use the TensorFlow backend for the following detectors:
-- ClassifierDrift
-- LearnedKernelDrift
-- LSDDDrift
-- LSDDDriftOnline
-- MMDDrift
-- MMDDriftOnline
-- SpotTheDiffDrift
-- ContextMMDDrift
+- [ClassifierDrift](../cd/methods/classifierdrift.ipynb)
+- [LearnedKernelDrift](../cd/methods/learnedkerneldrift.ipynb)
+- [LSDDDrift](../cd/methods/lsdddrift.ipynb)
+- [LSDDDriftOnline](../cd/methods/onlinelsdddrift.ipynb)
+- [MMDDrift](../cd/methods/mmddrift.ipynb)
+- [MMDDriftOnline](../cd/methods/onlinemmddrift.ipynb)
+- [SpotTheDiffDrift](../cd/methods/spotthediffdrift.ipynb)
+- [ContextMMDDrift](../cd/methods/contextmmddrift.ipynb)
 
 The TensorFlow installation is required to use the following detectors:
-- OutlierAE
-- OutlierAEGMM
-- LLR
-- OutlierSeq2Seq
-- OutlierVAE
-- OutlierVAEGMM
-- AdversarialAE
-- ModelDistillation
+- [OutlierAE](../od/methods/ae.ipynb)
+- [OutlierAEGMM](../od/methods/aegmm.ipynb)
+- [LLR](../od/methods/llr.ipynb)
+- [OutlierSeq2Seq](../od/methods/seq2seq.ipynb)
+- [OutlierVAE](../od/methods/vae.ipynb)
+- [OutlierVAEGMM](../od/methods/vaegmm.ipynb)
+- [AdversarialAE](../ad/methods/adversarialae.ipynb)
+- [ModelDistillation](../ad/methods/modeldistillation.ipynb)
 ```
 ````
 
@@ -169,8 +169,8 @@ pip install alibi-detect[numba]
 
 ```{div} sd-mb-1
 The Numba installation is required to use the following detectors:
-- CVMDriftOnline
-- FETDriftOnline
+- [CVMDriftOnline](../cd/methods/cvmdrift.ipynb)
+- [FETDriftOnline](../cd/methods/fetdrift.ipynb)
 ```
 ````
 


### PR DESCRIPTION
## What is this

This work branches off [`feature/dep-management`](https://github.com/SeldonIO/alibi-detect/pull/501) and Incorporates changes to the documentation for the dependency management functionality.

# Notes:

- The main issue here is how to handle optional dependencies for `conda` installs. We've come to the conclusion that we should keep the `conda` install large. This is opposed to not including certain dependencies and then documenting what extra dependencies are required to enable certain functionalities. The main reason for this decision was that we're kind of held hostage by the rest of the conda recipe community who seem to opt for larger installs themselves. For instance, it's impossible for us to make PyTorch optional without making transformers optional because PyTorch is a dependency of the transformers conda recipe. We could take the approach of trying to figure out what dependencies we need to eliminate in order to get the optional dependencies we want to enable but this will be very hard to maintain and test for. For instance, if another dependency adds or removes a dependency we want to keep optional then we have to be alerted to it to update our dependencies.
- Because PyTorch is included in transformers I've also removed that from the conda install tab in the install docs!

___

### What this PR doesn't include:

1. Changes to the notebooks resulting from changes to the public API are included in the PRs (`tf, tf-tfp` and `torch`) where those changes are implemented, not here.