### PR TITLE
Tabular classifier drift example - dummy trap

### DIFF
--- a/doc/source/examples/cd_clf_adult.ipynb
+++ b/doc/source/examples/cd_clf_adult.ipynb
@@ -206,7 +206,7 @@
     "# define numerical standard scaler.\n",
     "num_transf = StandardScaler()\n",
     "\n",
-    "# define categorical one-hot encoder.\n",
+    "# define categorical one-hot encoder with first columns dropped.\n",
     "cat_transf = OneHotEncoder(\n",
     "    categories=[range(len(x)) for x in adult.category_map.values()],\n",
     "    drop=\"first\",\n",

--- a/doc/source/examples/cd_clf_adult.ipynb
+++ b/doc/source/examples/cd_clf_adult.ipynb
@@ -209,7 +209,7 @@
     "# define categorical one-hot encoder.\n",
     "cat_transf = OneHotEncoder(\n",
     "    categories=[range(len(x)) for x in adult.category_map.values()],\n",
-    "    handle_unknown=\"ignore\"\n",
+    "    drop=\"first\",\n",
     ")\n",
     "\n",
     "# Define column transformer\n",
@@ -286,7 +286,7 @@
      "text": [
       "H0\n",
       "Drift? No!\n",
-      "p-value: 0.681\n",
+      "p-value: 0.665\n",
       "\n",
       "H1\n",
       "Drift? Yes!\n",
@@ -357,7 +357,6 @@
     "# define model\n",
     "model = GradientBoostingClassifier()\n",
     "\n",
-    "\n",
     "# define drift detector\n",
     "detector = ClassifierDrift(\n",
     "    x_ref=x_ref,\n",
@@ -402,7 +401,7 @@
      "text": [
       "H0\n",
       "Drift? No!\n",
-      "p-value: 0.457\n",
+      "p-value: 0.359\n",
       "\n",
       "H1\n",
       "Drift? Yes!\n",
@@ -484,14 +483,14 @@
      "text": [
       "H0\n",
       "Drift? No!\n",
-      "p-value: 0.670\n",
+      "p-value: 0.905\n",
       "\n",
       "H1\n",
       "Drift? Yes!\n",
       "p-value: 0.000\n",
       "\n",
-      "CPU times: user 5.13 s, sys: 4.92 ms, total: 5.14 s\n",
-      "Wall time: 5.13 s\n"
+      "CPU times: user 8.68 s, sys: 42.2 ms, total: 8.72 s\n",
+      "Wall time: 8.72 s\n"
      ]
     }
    ],
@@ -532,14 +531,14 @@
      "text": [
       "H0\n",
       "Drift? No!\n",
-      "p-value: 0.905\n",
+      "p-value: 0.952\n",
       "\n",
       "H1\n",
       "Drift? Yes!\n",
       "p-value: 0.000\n",
       "\n",
-      "CPU times: user 1.39 s, sys: 18.3 ms, total: 1.41 s\n",
-      "Wall time: 1.41 s\n"
+      "CPU times: user 2.02 s, sys: 12.5 ms, total: 2.03 s\n",
+      "Wall time: 2.03 s\n"
      ]
     }
    ],


### PR DESCRIPTION
Minor fix in `ClassifierDrift` sklearn example. Included `drop='first'` in OHE to address dummy trap, which is a standard procedure.