### PR TITLE
Upper version bound pytorch

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ extras_require = {
         "pystan<3.0"
     ],
     "torch": [
-        "torch>=1.7.0"
+        "torch>=1.7.0, <1.13.0"
     ],
     # https://github.com/SeldonIO/alibi-detect/issues/375 and 387
     "tensorflow": [
@@ -29,7 +29,7 @@ extras_require = {
         "pystan<3.0",
         "tensorflow_probability>=0.8.0, <0.18.0",
         "tensorflow>=2.2.0, !=2.6.0, !=2.6.1, <2.10.0",  # https://github.com/SeldonIO/alibi-detect/issues/375 and 387
-        "torch>=1.7.0"
+        "torch>=1.7.0, <1.13.0"
     ],
 }
 


### PR DESCRIPTION
Add an upper version bound to PyTorch for consistency with TensorFlow.