### PR TITLE
Send MMDDriftTorch self.kernel to device

### DIFF
--- a/alibi_detect/cd/pytorch/mmd.py
+++ b/alibi_detect/cd/pytorch/mmd.py
@@ -89,7 +89,7 @@ class MMDDriftTorch(BaseMMDDrift):
         # initialize kernel
         sigma = torch.from_numpy(sigma).to(self.device) if isinstance(sigma,  # type: ignore[assignment]
                                                                       np.ndarray) else None
-        self.kernel = kernel(sigma) if kernel == GaussianRBF else kernel
+        self.kernel = kernel(sigma).to(self.device) if kernel == GaussianRBF else kernel
 
         # compute kernel matrix for the reference data
         if self.infer_sigma or isinstance(sigma, torch.Tensor):


### PR DESCRIPTION
Addresses a bug where the `kernel` attribute of `MMDDriftTorch` was not being sent to the `device`.

Closes #586 