### PR TITLE
Fix to allow config.toml to be loaded with [meta] not present

### DIFF
--- a/alibi_detect/base.py
+++ b/alibi_detect/base.py
@@ -146,7 +146,7 @@ class DriftConfigMixin:
         """
         # Check for existing version_warning. meta is pop'd as don't want to pass as arg/kwarg
         meta = config.pop('meta', None)
-        meta = {} if meta is None else meta
+        meta = {} if meta is None else meta  # Needed because pydantic sets meta=None if it is missing from the config
         version_warning = meta.pop('version_warning', False)
         # Init detector
         detector = cls(**config)

--- a/alibi_detect/base.py
+++ b/alibi_detect/base.py
@@ -144,8 +144,10 @@ class DriftConfigMixin:
         config
             A config dictionary matching the schema's in :class:`~alibi_detect.saving.schemas`.
         """
-        # Check for exisiting version_warning. meta is pop'd as don't want to pass as arg/kwarg
-        version_warning = config.pop('meta', {}).pop('version_warning', False)
+        # Check for existing version_warning. meta is pop'd as don't want to pass as arg/kwarg
+        meta = config.pop('meta', None)
+        meta = {} if meta is None else meta
+        version_warning = meta.pop('version_warning', False)
         # Init detector
         detector = cls(**config)
         # Add version_warning

--- a/alibi_detect/saving/schemas.py
+++ b/alibi_detect/saving/schemas.py
@@ -100,7 +100,7 @@ class DetectorConfig(CustomBaseModel):
     "Name of the detector e.g. `MMDDrift`."
     backend: Literal['tensorflow', 'pytorch', 'sklearn'] = 'tensorflow'
     "The detector backend."
-    meta: Optional[MetaData]
+    meta: Optional[MetaData] = None
     "Config metadata. Should not be edited."
     # Note: Although not all detectors have a backend, we define in base class as `backend` also determines
     #  whether tf or torch models used for preprocess_fn.

--- a/alibi_detect/saving/tests/test_saving.py
+++ b/alibi_detect/saving/tests/test_saving.py
@@ -270,12 +270,13 @@ def preprocess_hiddenoutput(classifier, backend):
 
 @parametrize('cfg', CFGS)
 def test_load_simple_config(cfg, tmp_path):
-    x_ref_path = tmp_path.joinpath('x_ref.npy')
-    cfg_path = tmp_path.joinpath('config.toml')
+    save_dir = tmp_path
+    x_ref_path = str(save_dir.joinpath('x_ref.npy'))
+    cfg_path = save_dir.joinpath('config.toml')
     # Save x_ref in config.toml
     x_ref = cfg['x_ref']
     np.save(x_ref_path, x_ref)
-    cfg['x_ref'] = str(x_ref_path)
+    cfg['x_ref'] = 'x_ref.npy'
     # Save config.toml then load it
     with open(cfg_path, 'w') as f:
         toml.dump(cfg, f)

--- a/alibi_detect/saving/tests/test_saving.py
+++ b/alibi_detect/saving/tests/test_saving.py
@@ -66,7 +66,9 @@ REGISTERED_OBJECTS = registry.get_all()
 MMD_CFG = {
     'name': 'MMDDrift',
     'x_ref': np.array([[-0.30074928], [1.50240758], [0.43135768], [2.11295779], [0.79684913]]),
-    'p_val': 0.05
+    'p_val': 0.05,
+    'n_permutations': 150,
+    'data_type': 'tabular'
 }
 CFGS = [MMD_CFG]
 
@@ -270,6 +272,9 @@ def preprocess_hiddenoutput(classifier, backend):
 
 @parametrize('cfg', CFGS)
 def test_load_simple_config(cfg, tmp_path):
+    """
+    Test that a bare-bones `config.toml` without a [meta] field can be loaded by `load_detector`.
+    """
     save_dir = tmp_path
     x_ref_path = str(save_dir.joinpath('x_ref.npy'))
     cfg_path = save_dir.joinpath('config.toml')
@@ -282,6 +287,13 @@ def test_load_simple_config(cfg, tmp_path):
         toml.dump(cfg, f)
     cd = load_detector(cfg_path)
     assert cd.__class__.__name__ == cfg['name']
+    # Get config and compare to original (orginal cfg not fully spec'd so only compare items that are present)
+    cfg_new = cd.get_config()
+    for k, v in cfg.items():
+        if k == 'x_ref':
+            assert v == 'x_ref.npy'
+        else:
+            assert v == cfg_new[k]
 
 
 @parametrize('preprocess_fn', [preprocess_custom, preprocess_hiddenoutput])

--- a/alibi_detect/saving/tests/test_validate.py
+++ b/alibi_detect/saving/tests/test_validate.py
@@ -5,6 +5,7 @@ from pydantic import ValidationError
 from alibi_detect.saving import validate_config
 from alibi_detect.saving.saving import X_REF_FILENAME
 from alibi_detect.version import __config_spec__, __version__
+from copy import deepcopy
 
 # Define a detector config dict
 mmd_cfg = {
@@ -18,7 +19,7 @@ mmd_cfg = {
 }
 
 # Define a detector config dict without meta (as simple as it gets!)
-mmd_cfg_nometa = mmd_cfg.copy()
+mmd_cfg_nometa = deepcopy(mmd_cfg)
 mmd_cfg_nometa.pop('meta')
 
 

--- a/alibi_detect/saving/tests/test_validate.py
+++ b/alibi_detect/saving/tests/test_validate.py
@@ -16,19 +16,14 @@ mmd_cfg = {
     'x_ref': np.array([[-0.30074928], [1.50240758], [0.43135768], [2.11295779], [0.79684913]]),
     'p_val': 0.05
 }
-cfgs = [mmd_cfg]
-n_tests = len(cfgs)
+
+# Define a detector config dict without meta (as simple as it gets!)
+mmd_cfg_nometa = mmd_cfg.copy()
+mmd_cfg_nometa.pop('meta')
 
 
-@pytest.fixture
-def select_cfg(request):
-    return cfgs[request.param]
-
-
-@pytest.mark.parametrize('select_cfg', list(range(n_tests)), indirect=True)
-def test_validate_config(select_cfg):
-    cfg = select_cfg
-
+@pytest.mark.parametrize('cfg', [mmd_cfg])
+def test_validate_config(cfg):
     # Original cfg
     # Check original cfg doesn't raise errors
     cfg_full = validate_config(cfg, resolved=True)
@@ -81,3 +76,14 @@ def test_validate_config(select_cfg):
     with pytest.raises(ValidationError):
         cfg_err = validate_config(cfg_err, resolved=True)
     assert not cfg_err.get('meta').get('version_warning')
+
+
+@pytest.mark.parametrize('cfg', [mmd_cfg_nometa])
+def test_validate_config_wo_meta(cfg):
+    # Check a config w/o a meta dict can be validated
+    _ = validate_config(cfg, resolved=True)
+
+    # Check the unresolved case
+    cfg_unres = cfg.copy()
+    cfg_unres['x_ref'] = X_REF_FILENAME
+    _ = validate_config(cfg_unres)

--- a/alibi_detect/saving/validate.py
+++ b/alibi_detect/saving/validate.py
@@ -38,6 +38,7 @@ def validate_config(cfg: dict, resolved: bool = False) -> dict:
 
     # Get meta data
     meta = cfg.get('meta')
+    meta = {} if meta is None else meta
     version_warning = meta.get('version_warning', False)
     version = meta.get('version', None)
     config_spec = meta.get('config_spec', None)

--- a/alibi_detect/saving/validate.py
+++ b/alibi_detect/saving/validate.py
@@ -38,7 +38,7 @@ def validate_config(cfg: dict, resolved: bool = False) -> dict:
 
     # Get meta data
     meta = cfg.get('meta')
-    meta = {} if meta is None else meta
+    meta = {} if meta is None else meta  # Needed because pydantic sets meta=None if it is missing from the config
     version_warning = meta.get('version_warning', False)
     version = meta.get('version', None)
     config_spec = meta.get('config_spec', None)


### PR DESCRIPTION
https://github.com/SeldonIO/alibi-detect/pull/564 introduced a bug whereby `config.toml` files were not loadable via `load_detector` if the `[meta]` field was not present. The `[meta]` field is only present when `config.toml` files are generated by `save_detector`, hence why this was not picked up during previous CI.

This PR fixes this issue, and adds tests to check that `validate_config` and `load_detector` both work when `[meta]` is not present.

This will be released in a `v0.10.3` patch once merged.