### PR TITLE
Ignore tests in codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -23,3 +23,6 @@ comment:
   layout: "reach,diff,flags,tree"
   behavior: default
   require_changes: no
+
+ignore:
+  - "**/*test*"  # ignore tests themselves

--- a/codecov.yml
+++ b/codecov.yml
@@ -25,4 +25,5 @@ comment:
   require_changes: no
 
 ignore:
-  - "**/*test*"  # ignore tests themselves
+  - "**/tests/*"  # ignore anything in tests/ directories
+  - "**/test_*.py"  # ignore test_*.py files even if they are located elsewhere


### PR DESCRIPTION
Update codecov setting to ignore `test` directories.

Alibi equivalent to be opened post-approval.