### PR TITLE
Correct platform-specific installs in CI, and add codecov tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Typecheck with mypy
         run: |
-        mypy alibi_detect
+          mypy alibi_detect
 
       - name: Test with pytest
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install --upgrade --upgrade-strategy eager -r requirements/dev.txt
           python -m pip install --upgrade --upgrade-strategy eager -e .
-          if [ "$RUNNER_OS" != "Windows" ] && [ ${{ matrix.python-version < 3.10 }} ]; then  # Skip Prophet tests on Windows as installation complex. Skip on Python 3.10 as not supported.
+          if [ "$RUNNER_OS" != "Windows" ] && ${{ matrix.python-version < 3.10 }}; then  # Skip Prophet tests on Windows as installation complex. Skip on Python 3.10 as not supported.
             python -m pip install --upgrade --upgrade-strategy eager -e .[prophet]
           fi
           if [ "$RUNNER_OS" == "Linux" ]; then  # Currently, we only support KeOps on Linux.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,10 +51,10 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install --upgrade --upgrade-strategy eager -r requirements/dev.txt
           python -m pip install --upgrade --upgrade-strategy eager -e .
-          if [ "$RUNNER_OS" != "Windows" ] && [ ${{ matrix.python }} < '3.10' ]; then  # Skip Prophet tests on Windows as installation complex. Skip on Python 3.10 as not supported.
+          if [ "$RUNNER_OS" != "Windows" ] && [ ${{ matrix.python-version }} < '3.10' ]; then  # Skip Prophet tests on Windows as installation complex. Skip on Python 3.10 as not supported.
             python -m pip install --upgrade --upgrade-strategy eager -e .[prophet]
           fi
-          if [ "$RUNNER_OS" == "Linux"]; then  # Currently, we only support KeOps on Linux.
+          if [ "$RUNNER_OS" == "Linux" ]; then  # Currently, we only support KeOps on Linux.
             python -m pip install --upgrade --upgrade-strategy eager -e .[keops]
           fi
           python -m pip install --upgrade --upgrade-strategy eager -e .[tensorflow,torch]
@@ -70,7 +70,7 @@ jobs:
 
       - name: Test with pytest
         run: |
-          pytest alibi_detect
+          python -m pytest alibi_detect
 
       - name: Upload coverage to Codecov
         if: ${{ success() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install --upgrade --upgrade-strategy eager -r requirements/dev.txt
           python -m pip install --upgrade --upgrade-strategy eager -e .
-          if [ "$RUNNER_OS" != "Windows" ] && ${{ matrix.python-version < 3.10 }}; then  # Skip Prophet tests on Windows as installation complex. Skip on Python 3.10 as not supported.
+          if [ "$RUNNER_OS" != "Windows" ] && ${{ matrix.python-version < '3.10' }}; then  # Skip Prophet tests on Windows as installation complex. Skip on Python 3.10 as not supported.
             python -m pip install --upgrade --upgrade-strategy eager -e .[prophet]
           fi
           if [ "$RUNNER_OS" == "Linux" ]; then  # Currently, we only support KeOps on Linux.
@@ -66,7 +66,7 @@ jobs:
 
       - name: Typecheck with mypy
         run: |
-          mypy alibi_detect
+        mypy alibi_detect
 
       - name: Test with pytest
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install --upgrade --upgrade-strategy eager -r requirements/dev.txt
           python -m pip install --upgrade --upgrade-strategy eager -e .
-          if [ "$RUNNER_OS" != "Windows" ] && ${{ matrix.python-version < '3.10' }}; then  # Skip Prophet tests on Windows as installation complex. Skip on Python 3.10 as not supported.
+          if [ "$RUNNER_OS" != "Windows" ] && ${{ matrix.python-version <= 3.9 }}; then  # Skip Prophet tests on Windows as installation complex. Skip on Python 3.10 as not supported.
             python -m pip install --upgrade --upgrade-strategy eager -e .[prophet]
           fi
           if [ "$RUNNER_OS" == "Linux" ]; then  # Currently, we only support KeOps on Linux.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install --upgrade --upgrade-strategy eager -r requirements/dev.txt
           python -m pip install --upgrade --upgrade-strategy eager -e .
-          if [ "$RUNNER_OS" != "Windows" ] && ${{ matrix.python-version <= 3.9 }}; then  # Skip Prophet tests on Windows as installation complex. Skip on Python 3.10 as not supported.
+          if [ "$RUNNER_OS" != "Windows" ] && ${{ matrix.python-version != '3.10' }}; then  # Skip Prophet tests on Windows as installation complex. Skip on Python 3.10 as not supported.
             python -m pip install --upgrade --upgrade-strategy eager -e .[prophet]
           fi
           if [ "$RUNNER_OS" == "Linux" ]; then  # Currently, we only support KeOps on Linux.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Test with pytest
         run: |
-          python -m pytest alibi_detect
+          pytest alibi_detect
 
       - name: Upload coverage to Codecov
         if: ${{ success() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install --upgrade --upgrade-strategy eager -r requirements/dev.txt
           python -m pip install --upgrade --upgrade-strategy eager -e .
-          if [ "$RUNNER_OS" != "Windows" ] && [ ${{ matrix.python-version }} < '3.10' ]; then  # Skip Prophet tests on Windows as installation complex. Skip on Python 3.10 as not supported.
+          if [ "$RUNNER_OS" != "Windows" ] && [ ${{ matrix.python-version < 3.10 }} ]; then  # Skip Prophet tests on Windows as installation complex. Skip on Python 3.10 as not supported.
             python -m pip install --upgrade --upgrade-strategy eager -e .[prophet]
           fi
           if [ "$RUNNER_OS" == "Linux" ]; then  # Currently, we only support KeOps on Linux.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,6 @@ jobs:
           - os: macos-latest 
             python-version:  '3.10'
 
-    name: OS ${{ matrix.os }} - Python ${{ matrix.python-version }}
-              
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -77,7 +75,7 @@ jobs:
       - name: Upload coverage to Codecov
         if: ${{ success() }}
         run: |
-          codecov -F ${{ matrix.name }}
+          codecov -F ${{ matrix.os }}-${{ matrix.python-version }}
 
       - name: Build Python package
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
           - os: macos-latest 
             python-version:  '3.10'
 
+    name: OS ${{ matrix.os }} - Python ${{ matrix.python-version }}
+              
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -75,7 +77,7 @@ jobs:
       - name: Upload coverage to Codecov
         if: ${{ success() }}
         run: |
-          codecov
+          codecov -F ${{ matrix.name }}
 
       - name: Build Python package
         run: |

--- a/.github/workflows/test_all_notebooks.yml
+++ b/.github/workflows/test_all_notebooks.yml
@@ -41,7 +41,7 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install --upgrade --upgrade-strategy eager -r requirements/dev.txt -r testing/requirements.txt
           python -m pip install --upgrade --upgrade-strategy eager -e .
-          if [ "$RUNNER_OS" != "Windows" ] && [ ${{ matrix.python }} < '3.10' ]; then  # Skip Prophet tests on Windows as installation complex. Skip on Python 3.10 as not supported.
+          if [ "$RUNNER_OS" != "Windows" ] && ${{ matrix.python-version != '3.10' }}; then  # Skip Prophet tests on Windows as installation complex. Skip on Python 3.10 as not supported.
             python -m pip install --upgrade --upgrade-strategy eager -e .[prophet]
           fi
           python -m pip install --upgrade --upgrade-strategy eager -e .[torch,tensorflow]

--- a/.github/workflows/test_changed_notebooks.yml
+++ b/.github/workflows/test_changed_notebooks.yml
@@ -56,7 +56,7 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install --upgrade --upgrade-strategy eager -r requirements/dev.txt -r testing/requirements.txt
           python -m pip install --upgrade --upgrade-strategy eager -e .
-          if [ "$RUNNER_OS" != "Windows" ] && [ ${{ matrix.python }} < '3.10' ]; then  # Skip Prophet tests on Windows as installation complex. Skip on Python 3.10 as not supported.
+          if [ "$RUNNER_OS" != "Windows" ] && ${{ matrix.python-version != '3.10' }}; then  # Skip Prophet tests on Windows as installation complex. Skip on Python 3.10 as not supported.
             python -m pip install --upgrade --upgrade-strategy eager -e .[prophet]
           fi
           python -m pip install --upgrade --upgrade-strategy eager -e .[torch,tensorflow]

--- a/alibi_detect/utils/saving/__init__.py
+++ b/alibi_detect/utils/saving/__init__.py
@@ -1,1 +1,6 @@
-from alibi_detect.utils.saving.saving import save_detector, load_detector  # noqa
+from alibi_detect.utils.saving.saving import save_detector, load_detector
+
+__all__ = [
+    "save_detector",
+    "load_detector"
+]

--- a/alibi_detect/utils/saving/__init__.py
+++ b/alibi_detect/utils/saving/__init__.py
@@ -1,6 +1,1 @@
-from alibi_detect.utils.saving.saving import save_detector, load_detector
-
-__all__ = [
-    "save_detector",
-    "load_detector"
-]
+from alibi_detect.utils.saving.saving import save_detector, load_detector  # noqa

--- a/codecov.yml
+++ b/codecov.yml
@@ -23,3 +23,7 @@ comment:
   layout: "reach,diff,flags,tree"
   behavior: default
   require_changes: no
+
+ignore:
+  - "**/tests/*"  # ignore anything in tests/ directories
+  - "**/test_*.py"  # ignore test_*.py files even if they are located elsewhere

--- a/codecov.yml
+++ b/codecov.yml
@@ -23,3 +23,6 @@ comment:
   layout: "reach,diff,flags,tree"
   behavior: default
   require_changes: no
+
+ignore:
+  - "**/*test*"  # ignore tests themselves

--- a/codecov.yml
+++ b/codecov.yml
@@ -23,3 +23,7 @@ comment:
   layout: "reach,diff,flags,tree"
   behavior: default
   require_changes: no
+
+ignore:
+  - "**/tests/*"  # ignore anything in tests/ directories
+  - "**/test_*.py"  # ignore test_*.py files even if they are located elsewhere    

--- a/codecov.yml
+++ b/codecov.yml
@@ -23,7 +23,3 @@ comment:
   layout: "reach,diff,flags,tree"
   behavior: default
   require_changes: no
-
-ignore:
-  - "**/tests/*"  # ignore anything in tests/ directories
-  - "**/test_*.py"  # ignore test_*.py files even if they are located elsewhere

--- a/codecov.yml
+++ b/codecov.yml
@@ -23,7 +23,3 @@ comment:
   layout: "reach,diff,flags,tree"
   behavior: default
   require_changes: no
-
-ignore:
-  - "**/tests/*"  # ignore anything in tests/ directories
-  - "**/test_*.py"  # ignore test_*.py files even if they are located elsewhere    

--- a/codecov.yml
+++ b/codecov.yml
@@ -25,4 +25,5 @@ comment:
   require_changes: no
 
 ignore:
-  - "**/*test*"  # ignore tests themselves
+  - "**/tests/*"  # ignore anything in tests/ directories
+  - "**/test_*.py"  # ignore test_*.py files even if they are located elsewhere

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,6 @@ addopts =
     --tb native
     -W ignore
     --cov=alibi_detect
-    --cov-append
     --randomly-dont-reorganize
     --randomly-seed=0
     #-n auto


### PR DESCRIPTION
We were not actually running some ops dep-dependent tests (`keops` and `fbprophet`) in CI due to some syntax issues in the github action yaml's. This PR fixes this.

Codecov flags are also added so that we can view coverage on a per-build basis.

