### PR TITLE
Revert "Tabular classifier drift example - dummy trap (#557)"

### DIFF
--- a/doc/source/examples/cd_clf_adult.ipynb
+++ b/doc/source/examples/cd_clf_adult.ipynb
@@ -206,10 +206,10 @@
     "# define numerical standard scaler.\n",
     "num_transf = StandardScaler()\n",
     "\n",
-    "# define categorical one-hot encoder with first columns dropped.\n",
+    "# define categorical one-hot encoder.\n",
     "cat_transf = OneHotEncoder(\n",
     "    categories=[range(len(x)) for x in adult.category_map.values()],\n",
-    "    drop=\"first\",\n",
+    "    handle_unknown=\"ignore\"\n",
     ")\n",
     "\n",
     "# Define column transformer\n",
@@ -286,7 +286,7 @@
      "text": [
       "H0\n",
       "Drift? No!\n",
-      "p-value: 0.665\n",
+      "p-value: 0.681\n",
       "\n",
       "H1\n",
       "Drift? Yes!\n",
@@ -357,6 +357,7 @@
     "# define model\n",
     "model = GradientBoostingClassifier()\n",
     "\n",
+    "\n",
     "# define drift detector\n",
     "detector = ClassifierDrift(\n",
     "    x_ref=x_ref,\n",
@@ -401,7 +402,7 @@
      "text": [
       "H0\n",
       "Drift? No!\n",
-      "p-value: 0.359\n",
+      "p-value: 0.457\n",
       "\n",
       "H1\n",
       "Drift? Yes!\n",
@@ -483,14 +484,14 @@
      "text": [
       "H0\n",
       "Drift? No!\n",
-      "p-value: 0.905\n",
+      "p-value: 0.670\n",
       "\n",
       "H1\n",
       "Drift? Yes!\n",
       "p-value: 0.000\n",
       "\n",
-      "CPU times: user 8.68 s, sys: 42.2 ms, total: 8.72 s\n",
-      "Wall time: 8.72 s\n"
+      "CPU times: user 5.13 s, sys: 4.92 ms, total: 5.14 s\n",
+      "Wall time: 5.13 s\n"
      ]
     }
    ],
@@ -531,14 +532,14 @@
      "text": [
       "H0\n",
       "Drift? No!\n",
-      "p-value: 0.952\n",
+      "p-value: 0.905\n",
       "\n",
       "H1\n",
       "Drift? Yes!\n",
       "p-value: 0.000\n",
       "\n",
-      "CPU times: user 2.02 s, sys: 12.5 ms, total: 2.03 s\n",
-      "Wall time: 2.03 s\n"
+      "CPU times: user 1.39 s, sys: 18.3 ms, total: 1.41 s\n",
+      "Wall time: 1.41 s\n"
      ]
     }
    ],


### PR DESCRIPTION
This reverts commit 4e2419877f89cb7e72721644a947f8b390f123fb.
Fixes incorrect suggestion to drop first column for one-hot encoding for data preprocessing. 


Check this [gist](https://gist.github.com/RobertSamoilescu/c609ded901c6c50388b6648a73066fed) to see how dropping first column can affect the model performance.