### PR TITLE
Dev/upgrade prophet 1.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,9 @@ jobs:
         os: [ubuntu-latest]
         python-version: [ '3.7', '3.8', '3.9', '3.10.6' ]
         include: # Run macos and windows tests on only one python version
-          - os: windows-latest 
-            python-version:  '3.9'  # PyTorch doesn't yet have 3.10 support on Windows (https://pytorch.org/get-started/locally/#windows-python) 
-          - os: macos-latest 
+          - os: windows-latest
+            python-version:  '3.9'  # PyTorch doesn't yet have 3.10 support on Windows (https://pytorch.org/get-started/locally/#windows-python)
+          - os: macos-latest
             python-version:  '3.10.6'
 
     steps:
@@ -51,10 +51,8 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install --upgrade --upgrade-strategy eager -r requirements/dev.txt
           python -m pip install --upgrade --upgrade-strategy eager -e .
-          if [ "$RUNNER_OS" != "Windows" ] && ${{ matrix.python-version != '3.10.6' }}; then  # Skip Prophet tests on Windows as installation complex. Skip on Python 3.10 as not supported.
-            python -m pip install --upgrade --upgrade-strategy eager -e .[prophet]
-          fi
-          if [ "$RUNNER_OS" == "Linux" ]; then  # Currently, we only support KeOps on Linux.
+          python -m pip install --upgrade --upgrade-strategy eager -e .[prophet]
+          if [ "$RUNNER_OS" == "Linux"]; then  # Currently, we only support KeOps on Linux.
             python -m pip install --upgrade --upgrade-strategy eager -e .[keops]
           fi
           python -m pip install --upgrade --upgrade-strategy eager -e .[tensorflow,torch]

--- a/.github/workflows/test_all_notebooks.yml
+++ b/.github/workflows/test_all_notebooks.yml
@@ -41,9 +41,7 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install --upgrade --upgrade-strategy eager -r requirements/dev.txt -r testing/requirements.txt
           python -m pip install --upgrade --upgrade-strategy eager -e .
-          if [ "$RUNNER_OS" != "Windows" ] && ${{ matrix.python-version != '3.10' }}; then  # Skip Prophet tests on Windows as installation complex. Skip on Python 3.10 as not supported.
-            python -m pip install --upgrade --upgrade-strategy eager -e .[prophet]
-          fi
+          python -m pip install --upgrade --upgrade-strategy eager -e .[prophet]
           python -m pip install --upgrade --upgrade-strategy eager -e .[torch,tensorflow]
           python -m pip freeze
 

--- a/.github/workflows/test_changed_notebooks.yml
+++ b/.github/workflows/test_changed_notebooks.yml
@@ -56,9 +56,7 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install --upgrade --upgrade-strategy eager -r requirements/dev.txt -r testing/requirements.txt
           python -m pip install --upgrade --upgrade-strategy eager -e .
-          if [ "$RUNNER_OS" != "Windows" ] && ${{ matrix.python-version != '3.10' }}; then  # Skip Prophet tests on Windows as installation complex. Skip on Python 3.10 as not supported.
-            python -m pip install --upgrade --upgrade-strategy eager -e .[prophet]
-          fi
+          python -m pip install --upgrade --upgrade-strategy eager -e .[prophet]
           python -m pip install --upgrade --upgrade-strategy eager -e .[torch,tensorflow]
           python -m pip freeze
 

--- a/alibi_detect/od/prophet.py
+++ b/alibi_detect/od/prophet.py
@@ -1,4 +1,4 @@
-from fbprophet import Prophet
+from prophet import Prophet
 import logging
 import pandas as pd
 from typing import Dict, List, Union

--- a/alibi_detect/od/tests/test_prophet.py
+++ b/alibi_detect/od/tests/test_prophet.py
@@ -33,10 +33,10 @@ def prophet_params(request):
 
 @pytest.mark.parametrize('prophet_params', list(range(n_tests)), indirect=True)
 def test_prophet(prophet_params):
-    fbprophet = pytest.importorskip('fbprophet', reason="Prophet tests skipped as Prophet not installed")
+    prophet = pytest.importorskip('prophet', reason="Prophet tests skipped as Prophet not installed")
     growth, return_instance_score, return_forecast = prophet_params
     od = OutlierProphet(growth=growth)
-    assert isinstance(od.model, fbprophet.forecaster.Prophet)
+    assert isinstance(od.model, prophet.forecaster.Prophet)
     assert od.meta == {'name': 'OutlierProphet', 'detector_type': 'outlier', 'data_type': 'time-series',
                        'online': False, 'version': __version__}
     if growth == 'logistic':

--- a/alibi_detect/utils/missing_optional_dependency.py
+++ b/alibi_detect/utils/missing_optional_dependency.py
@@ -28,9 +28,7 @@ dict is used to control two behaviours:
     before the pip install message is issued as this is the most robust place to capture these differences.
 """
 ERROR_TYPES = {
-    "fbprophet": 'prophet',
-    "holidays": 'prophet',
-    "pystan": 'prophet',
+    "prophet": 'prophet',
     "tensorflow_probability": 'tensorflow',
     "tensorflow": 'tensorflow',
     "torch": 'torch',

--- a/setup.py
+++ b/setup.py
@@ -11,9 +11,7 @@ exec(open("alibi_detect/version.py").read())
 
 extras_require = {
     "prophet": [
-        "fbprophet>=0.5, <0.7",
-        "holidays==0.9.11",
-        "pystan<3.0"
+        "prophet>=1.1",
     ],
     "torch": [
         "torch>=1.7.0, <1.13.0"

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ exec(open("alibi_detect/version.py").read())
 
 extras_require = {
     "prophet": [
-        "prophet>=1.1",
+        "prophet>=1.1.0, <2.0.0",
     ],
     "torch": [
         "torch>=1.7.0, <1.13.0"
@@ -26,9 +26,7 @@ extras_require = {
         "torch>=1.7.0, <1.13.0"
     ],
     "all": [
-        "fbprophet>=0.5, <0.7",
-        "holidays==0.9.11",
-        "pystan<3.0",
+        "prophet>=1.1.0, <2.0.0",
         "tensorflow_probability>=0.8.0, <0.18.0",
         "tensorflow>=2.2.0, !=2.6.0, !=2.6.1, <2.10.0",  # https://github.com/SeldonIO/alibi-detect/issues/375 and 387
         "pykeops>=2.0.0, <2.2.0",


### PR DESCRIPTION
Resolves #626.

Went straight to 1.1 as [they have nice things](https://github.com/facebook/prophet/releases):
 - No dependency on `pystan` due to stopped development, the `stan` backend used now is `cmdstanpy`
 - Wheels provided for all major platforms and Python versions so no installation woes, means we should be able to run Windows tests

I've tested also that the sole example notebooks works as expected.