### PR TITLE
Reraise original error when handling missing dependencies

### DIFF
--- a/alibi_detect/utils/missing_optional_dependency.py
+++ b/alibi_detect/utils/missing_optional_dependency.py
@@ -107,7 +107,7 @@ def import_optional(module_name: str, names: Optional[List[str]] = None) -> Any:
         return module
     except (ImportError, ModuleNotFoundError) as err:
         if err.name is None:
-            raise TypeError()
+            raise err
         dep_name, *_ = err.name.split('.')
         if str(dep_name) not in ERROR_TYPES:
             raise err


### PR DESCRIPTION
Equivalent of https://github.com/SeldonIO/alibi/pull/783, can be left open for review before the next release.