### PR TITLE
Revert Python 3.10.6 pin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,12 +30,12 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ '3.7', '3.8', '3.9', '3.10.6' ]
+        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
         include: # Run macos and windows tests on only one python version
           - os: windows-latest
             python-version: '3.9'  # PyTorch doesn't yet have 3.10 support on Windows (https://pytorch.org/get-started/locally/#windows-python)
           - os: macos-latest
-            python-version: '3.10.6'
+            python-version: '3.10'
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Revert #619 now that mypy 0.981 is out. See https://github.com/python/mypy/issues/13627#issuecomment-1259095263.

Resolves #620.