### PR TITLE
Remove config_spec versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ See the [documentation](https://docs.seldon.io/projects/alibi-detect/en/latest/c
 
 ### Changed
 - Minimum `prophet` version bumped to `1.1.0` (used by `OutlierProphet`). This upgrade removes the dependency on `pystan` as `cmdstanpy` is used instead. This version also comes with pre-built wheels for all major platforms and Python versions, making both installation and testing easier ([#627](https://github.com/SeldonIO/alibi-detect/pull/627)).
+- **Breaking change** The `config_spec` field has been removed from detector config files. In order to load detectors serialized from in Alibi Detect versions, the field will need to be deleted from the detector's `config.toml` file. However, in any case, serialization compatibility across Alibi Detect versions is not currently guranteed. ([#641](https://github.com/SeldonIO/alibi-detect/pull/641)).
+
 
 ### Development
 - UTF-8 decoding is enforced when `README.md` is opened by `setup.py`. This is to prevent pip install errors on systems with `PYTHONIOENCODING` set to use other encoders ([#605](https://github.com/SeldonIO/alibi-detect/pull/605)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ See the [documentation](https://docs.seldon.io/projects/alibi-detect/en/latest/c
 
 ### Changed
 - Minimum `prophet` version bumped to `1.1.0` (used by `OutlierProphet`). This upgrade removes the dependency on `pystan` as `cmdstanpy` is used instead. This version also comes with pre-built wheels for all major platforms and Python versions, making both installation and testing easier ([#627](https://github.com/SeldonIO/alibi-detect/pull/627)).
-- **Breaking change** The `config_spec` field has been removed from detector config files. In order to load detectors serialized from in Alibi Detect versions, the field will need to be deleted from the detector's `config.toml` file. However, in any case, serialization compatibility across Alibi Detect versions is not currently guranteed. ([#641](https://github.com/SeldonIO/alibi-detect/pull/641)).
+- **Breaking change** The configuration field `config_spec` has been removed. In order to load detectors serialized from previous Alibi Detect versions, the field will need to be deleted from the detector's `config.toml` file. However, in any case, serialization compatibility across Alibi Detect versions is not currently guranteed. ([#641](https://github.com/SeldonIO/alibi-detect/pull/641)).
 
 
 ### Development

--- a/alibi_detect/base.py
+++ b/alibi_detect/base.py
@@ -4,7 +4,7 @@ import json
 import numpy as np
 from typing import Dict, Any, Optional
 from typing_extensions import Protocol, runtime_checkable
-from alibi_detect.version import __version__, __config_spec__
+from alibi_detect.version import __version__
 
 
 DEFAULT_META = {
@@ -173,7 +173,6 @@ class DriftConfigMixin:
             'name': name,
             'meta': {
                 'version': __version__,
-                'config_spec': __config_spec__,
             }
         }
 

--- a/alibi_detect/saving/schemas.py
+++ b/alibi_detect/saving/schemas.py
@@ -88,7 +88,6 @@ class CustomBaseModelWithKwargs(BaseModel):
 
 class MetaData(CustomBaseModel):
     version: str
-    config_spec: str
     version_warning: bool = False
 
 

--- a/alibi_detect/saving/tests/test_validate.py
+++ b/alibi_detect/saving/tests/test_validate.py
@@ -4,14 +4,13 @@ from pydantic import ValidationError
 
 from alibi_detect.saving import validate_config
 from alibi_detect.saving.saving import X_REF_FILENAME
-from alibi_detect.version import __config_spec__, __version__
+from alibi_detect.version import __version__
 from copy import deepcopy
 
 # Define a detector config dict
 mmd_cfg = {
     'meta': {
         'version': __version__,
-        'config_spec': __config_spec__,
     },
     'name': 'MMDDrift',
     'x_ref': np.array([[-0.30074928], [1.50240758], [0.43135768], [2.11295779], [0.79684913]]),
@@ -32,7 +31,6 @@ def test_validate_config(cfg):
     # Check cfg is returned with correct metadata
     meta = cfg_full.get('meta')  # pop as don't want to compare meta to cfg in next bit
     assert meta['version'] == __version__
-    assert meta['config_spec'] == __config_spec__
     assert not meta.pop('version_warning')  # pop this one to remove from next check
 
     # Check remaining values of items in cfg unchanged
@@ -45,15 +43,9 @@ def test_validate_config(cfg):
     _ = validate_config(cfg_unres)
     assert not cfg.get('meta').get('version_warning')
 
-    # Check warning raised and warning field added if version or config_spec different
+    # Check warning raised and warning field added if version different
     cfg_err = cfg.copy()
     cfg_err['meta']['version'] = '0.1.x'
-    with pytest.warns(Warning):  # error will be raised if a warning IS NOT raised
-        cfg_err = validate_config(cfg_err, resolved=True)
-    assert cfg_err.get('meta').get('version_warning')
-
-    cfg_err = cfg.copy()
-    cfg_err['meta']['config_spec'] = '0.x'
     with pytest.warns(Warning):  # error will be raised if a warning IS NOT raised
         cfg_err = validate_config(cfg_err, resolved=True)
     assert cfg_err.get('meta').get('version_warning')

--- a/alibi_detect/saving/validate.py
+++ b/alibi_detect/saving/validate.py
@@ -2,7 +2,7 @@ import warnings
 
 from alibi_detect.saving.schemas import (  # type: ignore[attr-defined]
     DETECTOR_CONFIGS, DETECTOR_CONFIGS_RESOLVED)
-from alibi_detect.version import __config_spec__, __version__
+from alibi_detect.version import __version__
 
 
 def validate_config(cfg: dict, resolved: bool = False) -> dict:
@@ -41,7 +41,6 @@ def validate_config(cfg: dict, resolved: bool = False) -> dict:
     meta = {} if meta is None else meta  # Needed because pydantic sets meta=None if it is missing from the config
     version_warning = meta.get('version_warning', False)
     version = meta.get('version', None)
-    config_spec = meta.get('config_spec', None)
 
     # Raise warning if config file already contains a version_warning
     if version_warning:
@@ -52,13 +51,6 @@ def validate_config(cfg: dict, resolved: bool = False) -> dict:
     if version is not None and version != __version__:
         warnings.warn(f'Config is from version {version} but current version is '
                       f'{__version__}. This may lead to breaking code or invalid results.')
-        cfg['meta'].update({'version_warning': True})
-
-    # Check config specification version
-    if config_spec is not None and config_spec != __config_spec__:
-        warnings.warn(f'Config has specification {version} when the installed '
-                      f'alibi-detect version expects specification {__config_spec__}.'
-                      'This may lead to breaking code or invalid results.')
         cfg['meta'].update({'version_warning': True})
 
     return cfg

--- a/alibi_detect/version.py
+++ b/alibi_detect/version.py
@@ -3,9 +3,3 @@
 # 2) we can import it in setup.py for the same reason
 # 3) we can import it into your module module
 __version__ = "0.10.4dev"
-
-# Define the config specification version. This is distinct to the library version above. It is only updated when
-# any detector config schema is updated, such that loading a previous config spec cannot be guaranteed to work.
-# The minor version number is associated with minor changes such as adding/removing/changing kwarg's, whilst the major
-# number is reserved for significant changes to the config layout.
-__config_spec__ = "0.1"

--- a/doc/source/overview/config_files.md
+++ b/doc/source/overview/config_files.md
@@ -461,9 +461,6 @@ artefacts before attempting the sometimes time-consuming operation of instantiat
 %```python
 %{'name': {'title': 'Name', 'type': 'string'},
 % 'version': {'title': 'Version', 'default': '0.8.1dev', 'type': 'string'},
-% 'config_spec': {'title': 'Config Spec',
-%  'default': '0.1.0dev',
-%  'type': 'string'},
 % 'backend': {'title': 'Backend',
 %  'default': 'tensorflow',
 %  'enum': ['tensorflow', 'pytorch'],


### PR DESCRIPTION
This PR removes the `config_spec` version number. This was added in v0.10.0, as an addition to the usual `version` number. This was intended to be distinct from `version`, with the idea being it would be used to signify changes to the format of the alibi-detect detector configuration file. However, it has proven to be of limited use, and leads to confusion (+ additional maintainability version). Since we don't guarantee save/load compatibility across `version`'s, the `config_spec` number is simply not needed. 