### PR TITLE
Follow-up to sklearn serialization

### DIFF
--- a/alibi_detect/cd/classifier.py
+++ b/alibi_detect/cd/classifier.py
@@ -23,7 +23,7 @@ class ClassifierDrift(DriftConfigMixin):
             self,
             x_ref: Union[np.ndarray, list],
             model: Union[ClassifierMixin, Callable],
-            backend: str = Framework.TENSORFLOW,
+            backend: str = 'tensorflow',
             p_val: float = .05,
             x_ref_preprocessed: bool = False,
             preprocess_at_init: bool = True,

--- a/alibi_detect/cd/classifier.py
+++ b/alibi_detect/cd/classifier.py
@@ -1,7 +1,7 @@
 import numpy as np
 from typing import Callable, Dict, Optional, Union
 from alibi_detect.utils.frameworks import has_pytorch, has_tensorflow, \
-    BackendValidator
+    BackendValidator, Framework
 from alibi_detect.base import DriftConfigMixin
 
 
@@ -23,7 +23,7 @@ class ClassifierDrift(DriftConfigMixin):
             self,
             x_ref: Union[np.ndarray, list],
             model: Union[ClassifierMixin, Callable],
-            backend: str = 'tensorflow',
+            backend: str = Framework.TENSORFLOW,
             p_val: float = .05,
             x_ref_preprocessed: bool = False,
             preprocess_at_init: bool = True,
@@ -149,9 +149,9 @@ class ClassifierDrift(DriftConfigMixin):
 
         backend = backend.lower()
         BackendValidator(
-            backend_options={'tensorflow': ['tensorflow'],
-                             'pytorch': ['pytorch'],
-                             'sklearn': ['sklearn']},
+            backend_options={Framework.TENSORFLOW: [Framework.TENSORFLOW],
+                             Framework.PYTORCH: [Framework.PYTORCH],
+                             Framework.SKLEARN: [Framework.SKLEARN]},
             construct_name=self.__class__.__name__
         ).verify_backend(backend)
 
@@ -162,13 +162,13 @@ class ClassifierDrift(DriftConfigMixin):
             pop_kwargs += ['optimizer']
         [kwargs.pop(k, None) for k in pop_kwargs]
 
-        if backend == 'tensorflow':
+        if backend == Framework.TENSORFLOW:
             pop_kwargs = ['device', 'dataloader', 'use_calibration', 'calibration_kwargs', 'use_oob']
             [kwargs.pop(k, None) for k in pop_kwargs]
             if dataset is None:
                 kwargs.update({'dataset': TFDataset})
             self._detector = ClassifierDriftTF(*args, **kwargs)  # type: ignore
-        elif backend == 'pytorch':
+        elif backend == Framework.PYTORCH:
             pop_kwargs = ['use_calibration', 'calibration_kwargs', 'use_oob']
             [kwargs.pop(k, None) for k in pop_kwargs]
             if dataset is None:

--- a/alibi_detect/cd/context_aware.py
+++ b/alibi_detect/cd/context_aware.py
@@ -1,7 +1,7 @@
 import logging
 import numpy as np
 from typing import Callable, Dict, Optional, Union, Tuple
-from alibi_detect.utils.frameworks import has_pytorch, has_tensorflow, BackendValidator
+from alibi_detect.utils.frameworks import has_pytorch, has_tensorflow, BackendValidator, Framework
 from alibi_detect.utils.warnings import deprecated_alias
 from alibi_detect.base import DriftConfigMixin
 
@@ -20,7 +20,7 @@ class ContextMMDDrift(DriftConfigMixin):
             self,
             x_ref: Union[np.ndarray, list],
             c_ref: np.ndarray,
-            backend: str = 'tensorflow',
+            backend: str = Framework.TENSORFLOW,
             p_val: float = .05,
             x_ref_preprocessed: bool = False,
             preprocess_at_init: bool = True,
@@ -93,8 +93,8 @@ class ContextMMDDrift(DriftConfigMixin):
 
         backend = backend.lower()
         BackendValidator(
-            backend_options={'tensorflow': ['tensorflow'],
-                             'pytorch': ['pytorch']},
+            backend_options={Framework.TENSORFLOW: [Framework.TENSORFLOW],
+                             Framework.PYTORCH: [Framework.PYTORCH]},
             construct_name=self.__class__.__name__
         ).verify_backend(backend)
 
@@ -104,7 +104,7 @@ class ContextMMDDrift(DriftConfigMixin):
         [kwargs.pop(k, None) for k in pop_kwargs]
 
         if x_kernel is None or c_kernel is None:
-            if backend == 'tensorflow':
+            if backend == Framework.TENSORFLOW:
                 from alibi_detect.utils.tensorflow.kernels import GaussianRBF
             else:
                 from alibi_detect.utils.pytorch.kernels import GaussianRBF  # type: ignore[no-redef]
@@ -113,7 +113,7 @@ class ContextMMDDrift(DriftConfigMixin):
             if c_kernel is None:
                 kwargs.update({'c_kernel': GaussianRBF})
 
-        if backend == 'tensorflow':
+        if backend == Framework.TENSORFLOW:
             kwargs.pop('device', None)
             self._detector = ContextMMDDriftTF(*args, **kwargs)  # type: ignore
         else:

--- a/alibi_detect/cd/context_aware.py
+++ b/alibi_detect/cd/context_aware.py
@@ -20,7 +20,7 @@ class ContextMMDDrift(DriftConfigMixin):
             self,
             x_ref: Union[np.ndarray, list],
             c_ref: np.ndarray,
-            backend: str = Framework.TENSORFLOW,
+            backend: str = 'tensorflow',
             p_val: float = .05,
             x_ref_preprocessed: bool = False,
             preprocess_at_init: bool = True,

--- a/alibi_detect/cd/keops/learned_kernel.py
+++ b/alibi_detect/cd/keops/learned_kernel.py
@@ -10,6 +10,7 @@ from typing import Callable, Dict, List, Optional, Union, Tuple
 from alibi_detect.cd.base import BaseLearnedKernelDrift
 from alibi_detect.utils.pytorch import get_device, predict_batch
 from alibi_detect.utils.pytorch.data import TorchDataset
+from alibi_detect.utils.frameworks import Framework
 
 
 class LearnedKernelDriftKeops(BaseLearnedKernelDrift):
@@ -130,7 +131,7 @@ class LearnedKernelDriftKeops(BaseLearnedKernelDrift):
             input_shape=input_shape,
             data_type=data_type
         )
-        self.meta.update({'backend': 'keops'})
+        self.meta.update({'backend': Framework.KEOPS})
 
         # Set device, define model and training kwargs
         self.device = get_device(device)

--- a/alibi_detect/cd/keops/learned_kernel.py
+++ b/alibi_detect/cd/keops/learned_kernel.py
@@ -131,7 +131,7 @@ class LearnedKernelDriftKeops(BaseLearnedKernelDrift):
             input_shape=input_shape,
             data_type=data_type
         )
-        self.meta.update({'backend': Framework.KEOPS})
+        self.meta.update({'backend': Framework.KEOPS.value})
 
         # Set device, define model and training kwargs
         self.device = get_device(device)

--- a/alibi_detect/cd/keops/mmd.py
+++ b/alibi_detect/cd/keops/mmd.py
@@ -168,7 +168,7 @@ class MMDDriftKeops(BaseMMDDrift):
         x_ref = torch.from_numpy(x_ref).float()  # type: ignore[assignment]
         x = torch.from_numpy(x).float()  # type: ignore[assignment]
         # compute kernel matrix, MMD^2 and apply permutation test
-        m, n = x_ref.shape[0], x.shape[0]
+        m, n = x_ref.shape[0], x.shape[0]  # type: ignore[union-attr]
         perms = [torch.randperm(m + n) for _ in range(self.n_permutations)]
         # TODO - Rethink typings (related to https://github.com/SeldonIO/alibi-detect/issues/540)
         x_all = torch.cat([x_ref, x], 0)  # type: ignore[list-item]

--- a/alibi_detect/cd/keops/mmd.py
+++ b/alibi_detect/cd/keops/mmd.py
@@ -83,7 +83,7 @@ class MMDDriftKeops(BaseMMDDrift):
             input_shape=input_shape,
             data_type=data_type
         )
-        self.meta.update({'backend': Framework.KEOPS})
+        self.meta.update({'backend': Framework.KEOPS.value})
 
         # set device
         self.device = get_device(device)

--- a/alibi_detect/cd/keops/mmd.py
+++ b/alibi_detect/cd/keops/mmd.py
@@ -6,6 +6,7 @@ from typing import Callable, Dict, List, Optional, Tuple, Union
 from alibi_detect.cd.base import BaseMMDDrift
 from alibi_detect.utils.keops.kernels import GaussianRBF
 from alibi_detect.utils.pytorch import get_device
+from alibi_detect.utils.frameworks import Framework
 
 logger = logging.getLogger(__name__)
 
@@ -82,7 +83,7 @@ class MMDDriftKeops(BaseMMDDrift):
             input_shape=input_shape,
             data_type=data_type
         )
-        self.meta.update({'backend': 'keops'})
+        self.meta.update({'backend': Framework.KEOPS})
 
         # set device
         self.device = get_device(device)

--- a/alibi_detect/cd/learned_kernel.py
+++ b/alibi_detect/cd/learned_kernel.py
@@ -1,6 +1,6 @@
 import numpy as np
 from typing import Callable, Dict, Optional, Union
-from alibi_detect.utils.frameworks import has_pytorch, has_tensorflow, has_keops, BackendValidator
+from alibi_detect.utils.frameworks import has_pytorch, has_tensorflow, has_keops, BackendValidator, Framework
 from alibi_detect.utils.warnings import deprecated_alias
 from alibi_detect.base import DriftConfigMixin
 
@@ -23,7 +23,7 @@ class LearnedKernelDrift(DriftConfigMixin):
             self,
             x_ref: Union[np.ndarray, list],
             kernel: Callable,
-            backend: str = 'tensorflow',
+            backend: str = Framework.TENSORFLOW,
             p_val: float = .05,
             x_ref_preprocessed: bool = False,
             preprocess_at_init: bool = True,
@@ -131,9 +131,9 @@ class LearnedKernelDrift(DriftConfigMixin):
 
         backend = backend.lower()
         BackendValidator(
-            backend_options={'tensorflow': ['tensorflow'],
-                             'pytorch': ['pytorch'],
-                             'keops': ['keops']},
+            backend_options={Framework.TENSORFLOW: [Framework.TENSORFLOW],
+                             Framework.PYTORCH: [Framework.PYTORCH],
+                             Framework.KEOPS: [Framework.KEOPS]},
             construct_name=self.__class__.__name__
         ).verify_backend(backend)
 
@@ -144,7 +144,7 @@ class LearnedKernelDrift(DriftConfigMixin):
             pop_kwargs += ['optimizer']
         [kwargs.pop(k, None) for k in pop_kwargs]
 
-        if backend == 'tensorflow':
+        if backend == Framework.TENSORFLOW:
             pop_kwargs = ['device', 'dataloader', 'batch_size_permutations', 'batch_size_predict']
             [kwargs.pop(k, None) for k in pop_kwargs]
             if dataset is None:
@@ -155,7 +155,7 @@ class LearnedKernelDrift(DriftConfigMixin):
                 kwargs.update({'dataset': TorchDataset})
             if dataloader is None:
                 kwargs.update({'dataloader': DataLoader})
-            if backend == 'pytorch':
+            if backend == Framework.PYTORCH:
                 pop_kwargs = ['batch_size_permutations', 'batch_size_predict']
                 [kwargs.pop(k, None) for k in pop_kwargs]
                 detector = LearnedKernelDriftTorch

--- a/alibi_detect/cd/learned_kernel.py
+++ b/alibi_detect/cd/learned_kernel.py
@@ -23,7 +23,7 @@ class LearnedKernelDrift(DriftConfigMixin):
             self,
             x_ref: Union[np.ndarray, list],
             kernel: Callable,
-            backend: str = Framework.TENSORFLOW,
+            backend: str = 'tensorflow',
             p_val: float = .05,
             x_ref_preprocessed: bool = False,
             preprocess_at_init: bool = True,

--- a/alibi_detect/cd/lsdd.py
+++ b/alibi_detect/cd/lsdd.py
@@ -1,6 +1,6 @@
 import numpy as np
 from typing import Callable, Dict, Optional, Union, Tuple
-from alibi_detect.utils.frameworks import has_pytorch, has_tensorflow, BackendValidator
+from alibi_detect.utils.frameworks import has_pytorch, has_tensorflow, BackendValidator, Framework
 from alibi_detect.utils.warnings import deprecated_alias
 from alibi_detect.base import DriftConfigMixin
 
@@ -16,7 +16,7 @@ class LSDDDrift(DriftConfigMixin):
     def __init__(
             self,
             x_ref: Union[np.ndarray, list],
-            backend: str = 'tensorflow',
+            backend: str = Framework.TENSORFLOW,
             p_val: float = .05,
             x_ref_preprocessed: bool = False,
             preprocess_at_init: bool = True,
@@ -82,8 +82,8 @@ class LSDDDrift(DriftConfigMixin):
 
         backend = backend.lower()
         BackendValidator(
-            backend_options={'tensorflow': ['tensorflow'],
-                             'pytorch': ['pytorch']},
+            backend_options={Framework.TENSORFLOW: [Framework.TENSORFLOW],
+                             Framework.PYTORCH: [Framework.PYTORCH]},
             construct_name=self.__class__.__name__
         ).verify_backend(backend)
 
@@ -92,7 +92,7 @@ class LSDDDrift(DriftConfigMixin):
         pop_kwargs = ['self', 'x_ref', 'backend', '__class__']
         [kwargs.pop(k, None) for k in pop_kwargs]
 
-        if backend == 'tensorflow':
+        if backend == Framework.TENSORFLOW:
             kwargs.pop('device', None)
             self._detector = LSDDDriftTF(*args, **kwargs)  # type: ignore
         else:

--- a/alibi_detect/cd/lsdd.py
+++ b/alibi_detect/cd/lsdd.py
@@ -16,7 +16,7 @@ class LSDDDrift(DriftConfigMixin):
     def __init__(
             self,
             x_ref: Union[np.ndarray, list],
-            backend: str = Framework.TENSORFLOW,
+            backend: str = 'tensorflow',
             p_val: float = .05,
             x_ref_preprocessed: bool = False,
             preprocess_at_init: bool = True,

--- a/alibi_detect/cd/lsdd_online.py
+++ b/alibi_detect/cd/lsdd_online.py
@@ -15,7 +15,7 @@ class LSDDDriftOnline(DriftConfigMixin):
             x_ref: Union[np.ndarray, list],
             ert: float,
             window_size: int,
-            backend: str = Framework.TENSORFLOW,
+            backend: str = 'tensorflow',
             preprocess_fn: Optional[Callable] = None,
             x_ref_preprocessed: bool = False,
             sigma: Optional[np.ndarray] = None,

--- a/alibi_detect/cd/lsdd_online.py
+++ b/alibi_detect/cd/lsdd_online.py
@@ -1,6 +1,6 @@
 import numpy as np
 from typing import Any, Callable, Dict, Optional, Union
-from alibi_detect.utils.frameworks import has_pytorch, has_tensorflow, BackendValidator
+from alibi_detect.utils.frameworks import has_pytorch, has_tensorflow, BackendValidator, Framework
 from alibi_detect.base import DriftConfigMixin
 if has_pytorch:
     from alibi_detect.cd.pytorch.lsdd_online import LSDDDriftOnlineTorch
@@ -15,7 +15,7 @@ class LSDDDriftOnline(DriftConfigMixin):
             x_ref: Union[np.ndarray, list],
             ert: float,
             window_size: int,
-            backend: str = 'tensorflow',
+            backend: str = Framework.TENSORFLOW,
             preprocess_fn: Optional[Callable] = None,
             x_ref_preprocessed: bool = False,
             sigma: Optional[np.ndarray] = None,
@@ -83,8 +83,8 @@ class LSDDDriftOnline(DriftConfigMixin):
 
         backend = backend.lower()
         BackendValidator(
-            backend_options={'tensorflow': ['tensorflow'],
-                             'pytorch': ['pytorch']},
+            backend_options={Framework.TENSORFLOW: [Framework.TENSORFLOW],
+                             Framework.PYTORCH: [Framework.PYTORCH]},
             construct_name=self.__class__.__name__
         ).verify_backend(backend)
 
@@ -93,7 +93,7 @@ class LSDDDriftOnline(DriftConfigMixin):
         pop_kwargs = ['self', 'x_ref', 'ert', 'window_size', 'backend', '__class__']
         [kwargs.pop(k, None) for k in pop_kwargs]
 
-        if backend == 'tensorflow':
+        if backend == Framework.TENSORFLOW:
             kwargs.pop('device', None)
             self._detector = LSDDDriftOnlineTF(*args, **kwargs)  # type: ignore
         else:

--- a/alibi_detect/cd/mmd.py
+++ b/alibi_detect/cd/mmd.py
@@ -22,7 +22,7 @@ class MMDDrift(DriftConfigMixin):
     def __init__(
             self,
             x_ref: Union[np.ndarray, list],
-            backend: str = Framework.TENSORFLOW,
+            backend: str = 'tensorflow',
             p_val: float = .05,
             x_ref_preprocessed: bool = False,
             preprocess_at_init: bool = True,

--- a/alibi_detect/cd/mmd_online.py
+++ b/alibi_detect/cd/mmd_online.py
@@ -1,6 +1,6 @@
 import numpy as np
 from typing import Any, Callable, Dict, Optional, Union
-from alibi_detect.utils.frameworks import has_pytorch, has_tensorflow, BackendValidator
+from alibi_detect.utils.frameworks import has_pytorch, has_tensorflow, BackendValidator, Framework
 from alibi_detect.base import DriftConfigMixin
 
 if has_pytorch:
@@ -16,7 +16,7 @@ class MMDDriftOnline(DriftConfigMixin):
             x_ref: Union[np.ndarray, list],
             ert: float,
             window_size: int,
-            backend: str = 'tensorflow',
+            backend: str = Framework.TENSORFLOW,
             preprocess_fn: Optional[Callable] = None,
             x_ref_preprocessed: bool = False,
             kernel: Optional[Callable] = None,
@@ -76,8 +76,8 @@ class MMDDriftOnline(DriftConfigMixin):
 
         backend = backend.lower()
         BackendValidator(
-            backend_options={'tensorflow': ['tensorflow'],
-                             'pytorch': ['pytorch']},
+            backend_options={Framework.TENSORFLOW: [Framework.TENSORFLOW],
+                             Framework.PYTORCH: [Framework.PYTORCH]},
             construct_name=self.__class__.__name__
         ).verify_backend(backend)
 
@@ -87,13 +87,13 @@ class MMDDriftOnline(DriftConfigMixin):
         [kwargs.pop(k, None) for k in pop_kwargs]
 
         if kernel is None:
-            if backend == 'tensorflow':
+            if backend == Framework.TENSORFLOW:
                 from alibi_detect.utils.tensorflow.kernels import GaussianRBF
             else:
                 from alibi_detect.utils.pytorch.kernels import GaussianRBF  # type: ignore
             kwargs.update({'kernel': GaussianRBF})
 
-        if backend == 'tensorflow':
+        if backend == Framework.TENSORFLOW:
             kwargs.pop('device', None)
             self._detector = MMDDriftOnlineTF(*args, **kwargs)  # type: ignore
         else:

--- a/alibi_detect/cd/mmd_online.py
+++ b/alibi_detect/cd/mmd_online.py
@@ -16,7 +16,7 @@ class MMDDriftOnline(DriftConfigMixin):
             x_ref: Union[np.ndarray, list],
             ert: float,
             window_size: int,
-            backend: str = Framework.TENSORFLOW,
+            backend: str = 'tensorflow',
             preprocess_fn: Optional[Callable] = None,
             x_ref_preprocessed: bool = False,
             kernel: Optional[Callable] = None,

--- a/alibi_detect/cd/model_uncertainty.py
+++ b/alibi_detect/cd/model_uncertainty.py
@@ -6,7 +6,7 @@ from alibi_detect.cd.ks import KSDrift
 from alibi_detect.cd.chisquare import ChiSquareDrift
 from alibi_detect.cd.preprocess import classifier_uncertainty, regressor_uncertainty
 from alibi_detect.cd.utils import encompass_batching, encompass_shuffling_and_batch_filling
-from alibi_detect.utils.frameworks import BackendValidator
+from alibi_detect.utils.frameworks import BackendValidator, Framework
 from alibi_detect.base import DriftConfigMixin
 
 logger = logging.getLogger(__name__)
@@ -85,8 +85,8 @@ class ClassifierUncertaintyDrift(DriftConfigMixin):
 
         if backend:
             backend = backend.lower()
-        BackendValidator(backend_options={'tensorflow': ['tensorflow'],
-                                          'pytorch': ['pytorch'],
+        BackendValidator(backend_options={Framework.TENSORFLOW: [Framework.TENSORFLOW],
+                                          Framework.PYTORCH: [Framework.PYTORCH],
                                           None: []},
                          construct_name=self.__class__.__name__).verify_backend(backend)
 
@@ -238,8 +238,8 @@ class RegressorUncertaintyDrift(DriftConfigMixin):
 
         if backend:
             backend = backend.lower()
-        BackendValidator(backend_options={'tensorflow': ['tensorflow'],
-                                          'pytorch': ['pytorch'],
+        BackendValidator(backend_options={Framework.TENSORFLOW: [Framework.TENSORFLOW],
+                                          Framework.PYTORCH: [Framework.PYTORCH],
                                           None: []},
                          construct_name=self.__class__.__name__).verify_backend(backend)
 
@@ -247,10 +247,10 @@ class RegressorUncertaintyDrift(DriftConfigMixin):
             model_fn = model
         else:
             if uncertainty_type == 'mc_dropout':
-                if backend == 'pytorch':
+                if backend == Framework.PYTORCH:
                     from alibi_detect.cd.pytorch.utils import activate_train_mode_for_dropout_layers
                     model = activate_train_mode_for_dropout_layers(model)
-                elif backend == 'tensorflow':
+                elif backend == Framework.TENSORFLOW:
                     logger.warning(
                         "MC dropout being applied to tensorflow model. May not be suitable if model contains"
                         "non-dropout layers with different train and inference time behaviour"
@@ -268,7 +268,7 @@ class RegressorUncertaintyDrift(DriftConfigMixin):
                 max_len=max_len
             )
 
-            if uncertainty_type == 'mc_dropout' and backend == 'tensorflow':
+            if uncertainty_type == 'mc_dropout' and backend == Framework.TENSORFLOW:
                 # To average over possible batchnorm effects as all layers evaluated in training mode.
                 model_fn = encompass_shuffling_and_batch_filling(model_fn, batch_size=batch_size)
 

--- a/alibi_detect/cd/pytorch/classifier.py
+++ b/alibi_detect/cd/pytorch/classifier.py
@@ -139,7 +139,7 @@ class ClassifierDriftTorch(BaseClassifierDrift):
         if preds_type not in ['probs', 'logits']:
             raise ValueError("'preds_type' should be 'probs' or 'logits'")
 
-        self.meta.update({'backend': Framework.PYTORCH})
+        self.meta.update({'backend': Framework.PYTORCH.value})
 
         # set device, define model and training kwargs
         self.device = get_device(device)

--- a/alibi_detect/cd/pytorch/classifier.py
+++ b/alibi_detect/cd/pytorch/classifier.py
@@ -12,6 +12,7 @@ from alibi_detect.utils.pytorch import get_device
 from alibi_detect.utils.pytorch.data import TorchDataset
 from alibi_detect.utils.pytorch.prediction import predict_batch
 from alibi_detect.utils.warnings import deprecated_alias
+from alibi_detect.utils.frameworks import Framework
 
 
 class ClassifierDriftTorch(BaseClassifierDrift):
@@ -138,7 +139,7 @@ class ClassifierDriftTorch(BaseClassifierDrift):
         if preds_type not in ['probs', 'logits']:
             raise ValueError("'preds_type' should be 'probs' or 'logits'")
 
-        self.meta.update({'backend': 'pytorch'})
+        self.meta.update({'backend': Framework.PYTORCH})
 
         # set device, define model and training kwargs
         self.device = get_device(device)

--- a/alibi_detect/cd/pytorch/context_aware.py
+++ b/alibi_detect/cd/pytorch/context_aware.py
@@ -102,7 +102,7 @@ class ContextMMDDriftTorch(BaseContextMMDDrift):
             data_type=data_type,
             verbose=verbose,
         )
-        self.meta.update({'backend': Framework.PYTORCH})
+        self.meta.update({'backend': Framework.PYTORCH.value})
 
         # set device
         self.device = get_device(device)

--- a/alibi_detect/cd/pytorch/context_aware.py
+++ b/alibi_detect/cd/pytorch/context_aware.py
@@ -6,6 +6,7 @@ from alibi_detect.cd.base import BaseContextMMDDrift
 from alibi_detect.utils.pytorch import get_device
 from alibi_detect.utils.pytorch.kernels import GaussianRBF
 from alibi_detect.utils.warnings import deprecated_alias
+from alibi_detect.utils.frameworks import Framework
 from alibi_detect.cd._domain_clf import _SVCDomainClf
 from tqdm import tqdm
 
@@ -101,7 +102,7 @@ class ContextMMDDriftTorch(BaseContextMMDDrift):
             data_type=data_type,
             verbose=verbose,
         )
-        self.meta.update({'backend': 'pytorch'})
+        self.meta.update({'backend': Framework.PYTORCH})
 
         # set device
         self.device = get_device(device)

--- a/alibi_detect/cd/pytorch/learned_kernel.py
+++ b/alibi_detect/cd/pytorch/learned_kernel.py
@@ -11,6 +11,7 @@ from alibi_detect.utils.pytorch import get_device
 from alibi_detect.utils.pytorch.distance import mmd2_from_kernel_matrix, batch_compute_kernel_matrix
 from alibi_detect.utils.pytorch.data import TorchDataset
 from alibi_detect.utils.warnings import deprecated_alias
+from alibi_detect.utils.frameworks import Framework
 
 
 class LearnedKernelDriftTorch(BaseLearnedKernelDrift):
@@ -124,7 +125,7 @@ class LearnedKernelDriftTorch(BaseLearnedKernelDrift):
             input_shape=input_shape,
             data_type=data_type
         )
-        self.meta.update({'backend': 'pytorch'})
+        self.meta.update({'backend': Framework.PYTORCH})
 
         # set device, define model and training kwargs
         self.device = get_device(device)

--- a/alibi_detect/cd/pytorch/learned_kernel.py
+++ b/alibi_detect/cd/pytorch/learned_kernel.py
@@ -125,7 +125,7 @@ class LearnedKernelDriftTorch(BaseLearnedKernelDrift):
             input_shape=input_shape,
             data_type=data_type
         )
-        self.meta.update({'backend': Framework.PYTORCH})
+        self.meta.update({'backend': Framework.PYTORCH.value})
 
         # set device, define model and training kwargs
         self.device = get_device(device)

--- a/alibi_detect/cd/pytorch/lsdd.py
+++ b/alibi_detect/cd/pytorch/lsdd.py
@@ -84,7 +84,7 @@ class LSDDDriftTorch(BaseLSDDDrift):
             input_shape=input_shape,
             data_type=data_type
         )
-        self.meta.update({'backend': Framework.PYTORCH})
+        self.meta.update({'backend': Framework.PYTORCH.value})
 
         # set device
         self.device = get_device(device)

--- a/alibi_detect/cd/pytorch/lsdd.py
+++ b/alibi_detect/cd/pytorch/lsdd.py
@@ -6,6 +6,7 @@ from alibi_detect.utils.pytorch import get_device
 from alibi_detect.utils.pytorch.kernels import GaussianRBF
 from alibi_detect.utils.pytorch.distance import permed_lsdds
 from alibi_detect.utils.warnings import deprecated_alias
+from alibi_detect.utils.frameworks import Framework
 
 
 class LSDDDriftTorch(BaseLSDDDrift):
@@ -83,7 +84,7 @@ class LSDDDriftTorch(BaseLSDDDrift):
             input_shape=input_shape,
             data_type=data_type
         )
-        self.meta.update({'backend': 'pytorch'})
+        self.meta.update({'backend': Framework.PYTORCH})
 
         # set device
         self.device = get_device(device)

--- a/alibi_detect/cd/pytorch/lsdd_online.py
+++ b/alibi_detect/cd/pytorch/lsdd_online.py
@@ -83,7 +83,7 @@ class LSDDDriftOnlineTorch(BaseMultiDriftOnline):
             input_shape=input_shape,
             data_type=data_type
         )
-        self.meta.update({'backend': Framework.PYTORCH})
+        self.meta.update({'backend': Framework.PYTORCH.value})
         self.n_kernel_centers = n_kernel_centers
         self.lambda_rd_max = lambda_rd_max
 

--- a/alibi_detect/cd/pytorch/lsdd_online.py
+++ b/alibi_detect/cd/pytorch/lsdd_online.py
@@ -5,6 +5,7 @@ from typing import Any, Callable, Optional, Union
 from alibi_detect.cd.base_online import BaseMultiDriftOnline
 from alibi_detect.utils.pytorch import get_device
 from alibi_detect.utils.pytorch import GaussianRBF, permed_lsdds, quantile
+from alibi_detect.utils.frameworks import Framework
 
 
 class LSDDDriftOnlineTorch(BaseMultiDriftOnline):
@@ -82,7 +83,7 @@ class LSDDDriftOnlineTorch(BaseMultiDriftOnline):
             input_shape=input_shape,
             data_type=data_type
         )
-        self.meta.update({'backend': 'pytorch'})
+        self.meta.update({'backend': Framework.PYTORCH})
         self.n_kernel_centers = n_kernel_centers
         self.lambda_rd_max = lambda_rd_max
 

--- a/alibi_detect/cd/pytorch/mmd.py
+++ b/alibi_detect/cd/pytorch/mmd.py
@@ -82,7 +82,7 @@ class MMDDriftTorch(BaseMMDDrift):
             input_shape=input_shape,
             data_type=data_type
         )
-        self.meta.update({'backend': Framework.PYTORCH})
+        self.meta.update({'backend': Framework.PYTORCH.value})
 
         # set device
         self.device = get_device(device)

--- a/alibi_detect/cd/pytorch/mmd.py
+++ b/alibi_detect/cd/pytorch/mmd.py
@@ -7,6 +7,7 @@ from alibi_detect.utils.pytorch import get_device
 from alibi_detect.utils.pytorch.distance import mmd2_from_kernel_matrix
 from alibi_detect.utils.pytorch.kernels import GaussianRBF
 from alibi_detect.utils.warnings import deprecated_alias
+from alibi_detect.utils.frameworks import Framework
 
 logger = logging.getLogger(__name__)
 
@@ -81,7 +82,7 @@ class MMDDriftTorch(BaseMMDDrift):
             input_shape=input_shape,
             data_type=data_type
         )
-        self.meta.update({'backend': 'pytorch'})
+        self.meta.update({'backend': Framework.PYTORCH})
 
         # set device
         self.device = get_device(device)

--- a/alibi_detect/cd/pytorch/mmd_online.py
+++ b/alibi_detect/cd/pytorch/mmd_online.py
@@ -6,6 +6,7 @@ from alibi_detect.cd.base_online import BaseMultiDriftOnline
 from alibi_detect.utils.pytorch import get_device
 from alibi_detect.utils.pytorch.kernels import GaussianRBF
 from alibi_detect.utils.pytorch import zero_diag, quantile
+from alibi_detect.utils.frameworks import Framework
 
 
 class MMDDriftOnlineTorch(BaseMultiDriftOnline):
@@ -75,7 +76,7 @@ class MMDDriftOnlineTorch(BaseMultiDriftOnline):
             input_shape=input_shape,
             data_type=data_type
         )
-        self.meta.update({'backend': 'pytorch'})
+        self.meta.update({'backend': Framework.PYTORCH})
 
         # set device
         self.device = get_device(device)

--- a/alibi_detect/cd/pytorch/mmd_online.py
+++ b/alibi_detect/cd/pytorch/mmd_online.py
@@ -76,7 +76,7 @@ class MMDDriftOnlineTorch(BaseMultiDriftOnline):
             input_shape=input_shape,
             data_type=data_type
         )
-        self.meta.update({'backend': Framework.PYTORCH})
+        self.meta.update({'backend': Framework.PYTORCH.value})
 
         # set device
         self.device = get_device(device)

--- a/alibi_detect/cd/sklearn/classifier.py
+++ b/alibi_detect/cd/sklearn/classifier.py
@@ -113,7 +113,7 @@ class ClassifierDriftSklearn(BaseClassifierDrift):
         if preds_type not in ['probs', 'scores']:
             raise ValueError("'preds_type' should be 'probs' or 'scores'")
 
-        self.meta.update({'backend': Framework.SKLEARN})
+        self.meta.update({'backend': Framework.SKLEARN.value})
         self.original_model = model
         self.use_calibration = use_calibration
         self.calibration_kwargs = dict() if calibration_kwargs is None else calibration_kwargs

--- a/alibi_detect/cd/sklearn/classifier.py
+++ b/alibi_detect/cd/sklearn/classifier.py
@@ -8,6 +8,7 @@ from sklearn.exceptions import NotFittedError
 from sklearn.ensemble import RandomForestClassifier
 from alibi_detect.cd.base import BaseClassifierDrift
 from alibi_detect.utils.warnings import deprecated_alias
+from alibi_detect.utils.frameworks import Framework
 
 logger = logging.getLogger(__name__)
 
@@ -112,7 +113,7 @@ class ClassifierDriftSklearn(BaseClassifierDrift):
         if preds_type not in ['probs', 'scores']:
             raise ValueError("'preds_type' should be 'probs' or 'scores'")
 
-        self.meta.update({'backend': 'sklearn'})
+        self.meta.update({'backend': Framework.SKLEARN})
         self.original_model = model
         self.use_calibration = use_calibration
         self.calibration_kwargs = dict() if calibration_kwargs is None else calibration_kwargs

--- a/alibi_detect/cd/spot_the_diff.py
+++ b/alibi_detect/cd/spot_the_diff.py
@@ -17,7 +17,7 @@ class SpotTheDiffDrift(DriftConfigMixin):
     def __init__(
             self,
             x_ref: Union[np.ndarray, list],
-            backend: str = Framework.TENSORFLOW,
+            backend: str = 'tensorflow',
             p_val: float = .05,
             x_ref_preprocessed: bool = False,
             preprocess_fn: Optional[Callable] = None,

--- a/alibi_detect/cd/spot_the_diff.py
+++ b/alibi_detect/cd/spot_the_diff.py
@@ -1,6 +1,6 @@
 import numpy as np
 from typing import Callable, Dict, Optional, Union
-from alibi_detect.utils.frameworks import has_pytorch, has_tensorflow, BackendValidator
+from alibi_detect.utils.frameworks import has_pytorch, has_tensorflow, BackendValidator, Framework
 from alibi_detect.base import DriftConfigMixin
 
 if has_pytorch:
@@ -17,7 +17,7 @@ class SpotTheDiffDrift(DriftConfigMixin):
     def __init__(
             self,
             x_ref: Union[np.ndarray, list],
-            backend: str = 'tensorflow',
+            backend: str = Framework.TENSORFLOW,
             p_val: float = .05,
             x_ref_preprocessed: bool = False,
             preprocess_fn: Optional[Callable] = None,
@@ -127,8 +127,8 @@ class SpotTheDiffDrift(DriftConfigMixin):
 
         backend = backend.lower()
         BackendValidator(
-            backend_options={'tensorflow': ['tensorflow'],
-                             'pytorch': ['pytorch']},
+            backend_options={Framework.TENSORFLOW: [Framework.TENSORFLOW],
+                             Framework.PYTORCH: [Framework.PYTORCH]},
             construct_name=self.__class__.__name__
         ).verify_backend(backend)
         kwargs = locals()
@@ -138,7 +138,7 @@ class SpotTheDiffDrift(DriftConfigMixin):
             pop_kwargs += ['optimizer']
         [kwargs.pop(k, None) for k in pop_kwargs]
 
-        if backend == 'tensorflow':
+        if backend == Framework.TENSORFLOW:
             pop_kwargs = ['device', 'dataloader']
             [kwargs.pop(k, None) for k in pop_kwargs]
             if dataset is None:

--- a/alibi_detect/cd/tensorflow/classifier.py
+++ b/alibi_detect/cd/tensorflow/classifier.py
@@ -130,7 +130,7 @@ class ClassifierDriftTF(BaseClassifierDrift):
         if preds_type not in ['probs', 'logits']:
             raise ValueError("'preds_type' should be 'probs' or 'logits'")
 
-        self.meta.update({'backend': Framework.TENSORFLOW})
+        self.meta.update({'backend': Framework.TENSORFLOW.value})
 
         # define and compile classifier model
         self.original_model = model

--- a/alibi_detect/cd/tensorflow/classifier.py
+++ b/alibi_detect/cd/tensorflow/classifier.py
@@ -10,6 +10,7 @@ from alibi_detect.utils.tensorflow.data import TFDataset
 from alibi_detect.utils.tensorflow.misc import clone_model
 from alibi_detect.utils.tensorflow.prediction import predict_batch
 from alibi_detect.utils.warnings import deprecated_alias
+from alibi_detect.utils.frameworks import Framework
 
 
 class ClassifierDriftTF(BaseClassifierDrift):
@@ -129,7 +130,7 @@ class ClassifierDriftTF(BaseClassifierDrift):
         if preds_type not in ['probs', 'logits']:
             raise ValueError("'preds_type' should be 'probs' or 'logits'")
 
-        self.meta.update({'backend': 'tensorflow'})
+        self.meta.update({'backend': Framework.TENSORFLOW})
 
         # define and compile classifier model
         self.original_model = model

--- a/alibi_detect/cd/tensorflow/context_aware.py
+++ b/alibi_detect/cd/tensorflow/context_aware.py
@@ -98,7 +98,7 @@ class ContextMMDDriftTF(BaseContextMMDDrift):
             data_type=data_type,
             verbose=verbose
         )
-        self.meta.update({'backend': Framework.TENSORFLOW})
+        self.meta.update({'backend': Framework.TENSORFLOW.value})
 
         # initialize kernel
         self.x_kernel = x_kernel(init_sigma_fn=_sigma_median_diag) if x_kernel == GaussianRBF else x_kernel

--- a/alibi_detect/cd/tensorflow/context_aware.py
+++ b/alibi_detect/cd/tensorflow/context_aware.py
@@ -6,6 +6,7 @@ from typing import Callable, Dict, Optional, Tuple, Union, List
 from alibi_detect.cd.base import BaseContextMMDDrift
 from alibi_detect.utils.tensorflow.kernels import GaussianRBF
 from alibi_detect.utils.warnings import deprecated_alias
+from alibi_detect.utils.frameworks import Framework
 from alibi_detect.cd._domain_clf import _SVCDomainClf
 from tqdm import tqdm
 
@@ -97,7 +98,7 @@ class ContextMMDDriftTF(BaseContextMMDDrift):
             data_type=data_type,
             verbose=verbose
         )
-        self.meta.update({'backend': 'tensorflow'})
+        self.meta.update({'backend': Framework.TENSORFLOW})
 
         # initialize kernel
         self.x_kernel = x_kernel(init_sigma_fn=_sigma_median_diag) if x_kernel == GaussianRBF else x_kernel

--- a/alibi_detect/cd/tensorflow/learned_kernel.py
+++ b/alibi_detect/cd/tensorflow/learned_kernel.py
@@ -7,6 +7,7 @@ from alibi_detect.utils.tensorflow.data import TFDataset
 from alibi_detect.utils.tensorflow.misc import clone_model
 from alibi_detect.utils.tensorflow.distance import mmd2_from_kernel_matrix, batch_compute_kernel_matrix
 from alibi_detect.utils.warnings import deprecated_alias
+from alibi_detect.utils.frameworks import Framework
 
 
 class LearnedKernelDriftTF(BaseLearnedKernelDrift):
@@ -113,7 +114,7 @@ class LearnedKernelDriftTF(BaseLearnedKernelDrift):
             input_shape=input_shape,
             data_type=data_type
         )
-        self.meta.update({'backend': 'tensorflow'})
+        self.meta.update({'backend': Framework.TENSORFLOW})
 
         # define and compile kernel
         self.original_kernel = kernel

--- a/alibi_detect/cd/tensorflow/learned_kernel.py
+++ b/alibi_detect/cd/tensorflow/learned_kernel.py
@@ -114,7 +114,7 @@ class LearnedKernelDriftTF(BaseLearnedKernelDrift):
             input_shape=input_shape,
             data_type=data_type
         )
-        self.meta.update({'backend': Framework.TENSORFLOW})
+        self.meta.update({'backend': Framework.TENSORFLOW.value})
 
         # define and compile kernel
         self.original_kernel = kernel

--- a/alibi_detect/cd/tensorflow/lsdd.py
+++ b/alibi_detect/cd/tensorflow/lsdd.py
@@ -79,7 +79,7 @@ class LSDDDriftTF(BaseLSDDDrift):
             input_shape=input_shape,
             data_type=data_type
         )
-        self.meta.update({'backend': Framework.TENSORFLOW})
+        self.meta.update({'backend': Framework.TENSORFLOW.value})
 
         if self.preprocess_at_init or self.preprocess_fn is None or self.x_ref_preprocessed:
             x_ref = tf.convert_to_tensor(self.x_ref)

--- a/alibi_detect/cd/tensorflow/lsdd.py
+++ b/alibi_detect/cd/tensorflow/lsdd.py
@@ -5,6 +5,7 @@ from alibi_detect.cd.base import BaseLSDDDrift
 from alibi_detect.utils.tensorflow.kernels import GaussianRBF
 from alibi_detect.utils.tensorflow.distance import permed_lsdds
 from alibi_detect.utils.warnings import deprecated_alias
+from alibi_detect.utils.frameworks import Framework
 
 
 class LSDDDriftTF(BaseLSDDDrift):
@@ -78,7 +79,7 @@ class LSDDDriftTF(BaseLSDDDrift):
             input_shape=input_shape,
             data_type=data_type
         )
-        self.meta.update({'backend': 'tensorflow'})
+        self.meta.update({'backend': Framework.TENSORFLOW})
 
         if self.preprocess_at_init or self.preprocess_fn is None or self.x_ref_preprocessed:
             x_ref = tf.convert_to_tensor(self.x_ref)

--- a/alibi_detect/cd/tensorflow/lsdd_online.py
+++ b/alibi_detect/cd/tensorflow/lsdd_online.py
@@ -78,7 +78,7 @@ class LSDDDriftOnlineTF(BaseMultiDriftOnline):
             input_shape=input_shape,
             data_type=data_type
         )
-        self.meta.update({'backend': Framework.TENSORFLOW})
+        self.meta.update({'backend': Framework.TENSORFLOW.value})
         self.n_kernel_centers = n_kernel_centers
         self.lambda_rd_max = lambda_rd_max
 

--- a/alibi_detect/cd/tensorflow/lsdd_online.py
+++ b/alibi_detect/cd/tensorflow/lsdd_online.py
@@ -4,6 +4,7 @@ import tensorflow as tf
 from typing import Any, Callable, Optional, Union
 from alibi_detect.cd.base_online import BaseMultiDriftOnline
 from alibi_detect.utils.tensorflow import GaussianRBF, quantile, permed_lsdds
+from alibi_detect.utils.frameworks import Framework
 
 
 class LSDDDriftOnlineTF(BaseMultiDriftOnline):
@@ -77,7 +78,7 @@ class LSDDDriftOnlineTF(BaseMultiDriftOnline):
             input_shape=input_shape,
             data_type=data_type
         )
-        self.meta.update({'backend': 'tensorflow'})
+        self.meta.update({'backend': Framework.TENSORFLOW})
         self.n_kernel_centers = n_kernel_centers
         self.lambda_rd_max = lambda_rd_max
 

--- a/alibi_detect/cd/tensorflow/mmd.py
+++ b/alibi_detect/cd/tensorflow/mmd.py
@@ -77,7 +77,7 @@ class MMDDriftTF(BaseMMDDrift):
             input_shape=input_shape,
             data_type=data_type
         )
-        self.meta.update({'backend': Framework.TENSORFLOW})
+        self.meta.update({'backend': Framework.TENSORFLOW.value})
 
         # initialize kernel
         if isinstance(sigma, np.ndarray):

--- a/alibi_detect/cd/tensorflow/mmd.py
+++ b/alibi_detect/cd/tensorflow/mmd.py
@@ -6,6 +6,7 @@ from alibi_detect.cd.base import BaseMMDDrift
 from alibi_detect.utils.tensorflow.distance import mmd2_from_kernel_matrix
 from alibi_detect.utils.tensorflow.kernels import GaussianRBF
 from alibi_detect.utils.warnings import deprecated_alias
+from alibi_detect.utils.frameworks import Framework
 
 logger = logging.getLogger(__name__)
 
@@ -76,7 +77,7 @@ class MMDDriftTF(BaseMMDDrift):
             input_shape=input_shape,
             data_type=data_type
         )
-        self.meta.update({'backend': 'tensorflow'})
+        self.meta.update({'backend': Framework.TENSORFLOW})
 
         # initialize kernel
         if isinstance(sigma, np.ndarray):

--- a/alibi_detect/cd/tensorflow/mmd_online.py
+++ b/alibi_detect/cd/tensorflow/mmd_online.py
@@ -71,7 +71,7 @@ class MMDDriftOnlineTF(BaseMultiDriftOnline):
             input_shape=input_shape,
             data_type=data_type
         )
-        self.meta.update({'backend': Framework.TENSORFLOW})
+        self.meta.update({'backend': Framework.TENSORFLOW.value})
 
         # initialize kernel
         if isinstance(sigma, np.ndarray):

--- a/alibi_detect/cd/tensorflow/mmd_online.py
+++ b/alibi_detect/cd/tensorflow/mmd_online.py
@@ -5,6 +5,7 @@ from typing import Any, Callable, Optional, Union
 from alibi_detect.cd.base_online import BaseMultiDriftOnline
 from alibi_detect.utils.tensorflow.kernels import GaussianRBF
 from alibi_detect.utils.tensorflow import zero_diag, quantile, subset_matrix
+from alibi_detect.utils.frameworks import Framework
 
 
 class MMDDriftOnlineTF(BaseMultiDriftOnline):
@@ -70,7 +71,7 @@ class MMDDriftOnlineTF(BaseMultiDriftOnline):
             input_shape=input_shape,
             data_type=data_type
         )
-        self.meta.update({'backend': 'tensorflow'})
+        self.meta.update({'backend': Framework.TENSORFLOW})
 
         # initialize kernel
         if isinstance(sigma, np.ndarray):

--- a/alibi_detect/cd/utils.py
+++ b/alibi_detect/cd/utils.py
@@ -4,6 +4,7 @@ from typing import Callable, Dict, Optional, Tuple, Union
 
 import numpy as np
 from alibi_detect.utils.sampling import reservoir_sampling
+from alibi_detect.utils.frameworks import Framework
 
 logger = logging.getLogger(__name__)
 
@@ -63,9 +64,9 @@ def encompass_batching(
     backend = backend.lower()
     kwargs = {'batch_size': batch_size, 'tokenizer': tokenizer, 'max_len': max_len,
               'preprocess_batch_fn': preprocess_batch_fn}
-    if backend == 'tensorflow':
+    if backend == Framework.TENSORFLOW:
         from alibi_detect.cd.tensorflow.preprocess import preprocess_drift
-    elif backend == 'pytorch':
+    elif backend == Framework.PYTORCH:
         from alibi_detect.cd.pytorch.preprocess import preprocess_drift  # type: ignore[no-redef]
         kwargs['device'] = device
     else:

--- a/alibi_detect/saving/_sklearn/saving.py
+++ b/alibi_detect/saving/_sklearn/saving.py
@@ -35,7 +35,7 @@ def save_model_config(model: BaseEstimator,
     filepath = base_path.joinpath(local_path)
     save_model(model, filepath=filepath, save_dir='model')
     cfg_model = {
-        'flavour': Framework.SKLEARN,
+        'flavour': Framework.SKLEARN.value,
         'src': local_path.joinpath('model')
     }
     return cfg_model

--- a/alibi_detect/saving/_sklearn/saving.py
+++ b/alibi_detect/saving/_sklearn/saving.py
@@ -2,9 +2,10 @@ import logging
 import os
 from pathlib import Path
 from typing import Union
-
 import joblib
 from sklearn.base import BaseEstimator
+
+from alibi_detect.utils.frameworks import Framework
 
 logger = logging.getLogger(__name__)
 
@@ -34,7 +35,7 @@ def save_model_config(model: BaseEstimator,
     filepath = base_path.joinpath(local_path)
     save_model(model, filepath=filepath, save_dir='model')
     cfg_model = {
-        'flavour': 'sklearn',
+        'flavour': Framework.SKLEARN,
         'src': local_path.joinpath('model')
     }
     return cfg_model

--- a/alibi_detect/saving/_tensorflow/loading.py
+++ b/alibi_detect/saving/_tensorflow/loading.py
@@ -25,6 +25,7 @@ from alibi_detect.od import (LLR, IForest, Mahalanobis, OutlierAE,
                              OutlierVAE, OutlierVAEGMM, SpectralResidual)
 from alibi_detect.od.llr import build_model
 from alibi_detect.utils.tensorflow.kernels import DeepKernel
+from alibi_detect.utils.frameworks import Framework
 # Below imports are used for legacy loading, and will be removed (or moved to utils/loading.py) in the future
 from alibi_detect.version import __version__
 from alibi_detect.base import Detector
@@ -214,7 +215,7 @@ def load_detector_legacy(filepath: Union[str, os.PathLike], suffix: str, **kwarg
         warnings.warn('Trying to load detector from an older version.'
                       'This may lead to breaking code or invalid results.')
 
-    if 'backend' in list(meta_dict.keys()) and meta_dict['backend'] == 'pytorch':
+    if 'backend' in list(meta_dict.keys()) and meta_dict['backend'] == Framework.PYTORCH:
         raise NotImplementedError('Detectors with PyTorch backend are not yet supported.')
 
     detector_name = meta_dict['name']

--- a/alibi_detect/saving/_tensorflow/saving.py
+++ b/alibi_detect/saving/_tensorflow/saving.py
@@ -83,7 +83,7 @@ def save_model_config(model: Callable,
         filepath = base_path.joinpath(local_path)
         save_model(model, filepath=filepath, save_dir='model')
         cfg_model = {
-            'flavour': Framework.TENSORFLOW,
+            'flavour': Framework.TENSORFLOW.value,
             'src': local_path.joinpath('model')
         }
     return cfg_model, cfg_embed
@@ -149,7 +149,7 @@ def save_embedding_config(embed: TransformerEmbedding,
     cfg_embed.update({'type': embed.emb_type})
     cfg_embed.update({'layers': embed.hs_emb.keywords['layers']})
     cfg_embed.update({'src': local_path})
-    cfg_embed.update({'flavour': Framework.TENSORFLOW})
+    cfg_embed.update({'flavour': Framework.TENSORFLOW.value})
 
     # Save embedding model
     logger.info('Saving embedding model to {}.'.format(filepath))

--- a/alibi_detect/saving/_tensorflow/saving.py
+++ b/alibi_detect/saving/_tensorflow/saving.py
@@ -22,6 +22,7 @@ from alibi_detect.od import (LLR, IForest, Mahalanobis, OutlierAE,
 from alibi_detect.utils._types import Literal
 from alibi_detect.utils.tensorflow.kernels import GaussianRBF
 from alibi_detect.utils.missing_optional_dependency import MissingDependency
+from alibi_detect.utils.frameworks import Framework
 
 logger = logging.getLogger(__name__)
 
@@ -82,7 +83,7 @@ def save_model_config(model: Callable,
         filepath = base_path.joinpath(local_path)
         save_model(model, filepath=filepath, save_dir='model')
         cfg_model = {
-            'flavour': 'tensorflow',
+            'flavour': Framework.TENSORFLOW,
             'src': local_path.joinpath('model')
         }
     return cfg_model, cfg_embed
@@ -148,7 +149,7 @@ def save_embedding_config(embed: TransformerEmbedding,
     cfg_embed.update({'type': embed.emb_type})
     cfg_embed.update({'layers': embed.hs_emb.keywords['layers']})
     cfg_embed.update({'src': local_path})
-    cfg_embed.update({'flavour': 'tensorflow'})
+    cfg_embed.update({'flavour': Framework.TENSORFLOW})
 
     # Save embedding model
     logger.info('Saving embedding model to {}.'.format(filepath))

--- a/alibi_detect/saving/loading.py
+++ b/alibi_detect/saving/loading.py
@@ -17,7 +17,7 @@ from alibi_detect.saving._sklearn import load_model_sk
 from alibi_detect.saving.validate import validate_config
 from alibi_detect.base import Detector, ConfigurableDetector
 from alibi_detect.utils.frameworks import has_tensorflow, has_pytorch
-from alibi_detect.saving.schemas import SupportedModels_tf, SupportedModels_torch
+from alibi_detect.saving.schemas import supported_models_tf, supported_models_torch
 
 if TYPE_CHECKING:
     import tensorflow as tf
@@ -215,10 +215,10 @@ def _load_preprocess_config(cfg: dict) -> Optional[Callable]:
             emb = kwargs.pop('embedding')  # embedding passed to preprocess_drift as `model` therefore remove
 
             # Backend specifics
-            if has_tensorflow and isinstance(model, SupportedModels_tf):
+            if has_tensorflow and isinstance(model, supported_models_tf):
                 model = prep_model_and_emb_tf(model, emb)
                 kwargs.pop('device')
-            elif has_pytorch and isinstance(model, SupportedModels_torch):
+            elif has_pytorch and isinstance(model, supported_models_torch):
                 raise NotImplementedError('Loading preprocess_fn for PyTorch not yet supported.')
 #               device = cfg['device'] # TODO - device should be set already - check
 #               kwargs.update({'model': kwargs['model'].to(device)})  # TODO - need .to(device) here?

--- a/alibi_detect/saving/loading.py
+++ b/alibi_detect/saving/loading.py
@@ -16,7 +16,7 @@ from alibi_detect.saving._tensorflow import load_detector_legacy, load_embedding
 from alibi_detect.saving._sklearn import load_model_sk
 from alibi_detect.saving.validate import validate_config
 from alibi_detect.base import Detector, ConfigurableDetector
-from alibi_detect.utils.frameworks import has_tensorflow, has_pytorch
+from alibi_detect.utils.frameworks import has_tensorflow, has_pytorch, Framework
 from alibi_detect.saving.schemas import supported_models_tf, supported_models_torch
 
 if TYPE_CHECKING:
@@ -130,7 +130,7 @@ def _load_detector_config(filepath: Union[str, os.PathLike]) -> ConfigurableDete
 
     # Backend
     backend = cfg.get('backend', None)
-    if backend is not None and backend.lower() not in ('tensorflow', 'sklearn'):
+    if backend is not None and backend.lower() not in (Framework.TENSORFLOW, Framework.SKLEARN):
         raise NotImplementedError('Loading detectors with pytorch or keops backend is not yet supported.')
 
     # Init detector from config
@@ -162,7 +162,7 @@ def _init_detector(cfg: dict) -> ConfigurableDetector:
     return detector
 
 
-def _load_kernel_config(cfg: dict, backend: str = 'tensorflow') -> Callable:
+def _load_kernel_config(cfg: dict, backend: str = Framework.TENSORFLOW) -> Callable:
     """
     Loads a kernel from a kernel config dict.
 
@@ -179,7 +179,7 @@ def _load_kernel_config(cfg: dict, backend: str = 'tensorflow') -> Callable:
     -------
     The kernel.
     """
-    if backend == 'tensorflow':
+    if backend == Framework.TENSORFLOW:
         kernel = load_kernel_config_tf(cfg)
     else:
         kernel = None
@@ -264,9 +264,9 @@ def _load_model_config(cfg: dict) -> Callable:
         raise FileNotFoundError("The `src` field is not a recognised directory. It should be a directory containing "
                                 "a compatible model.")
 
-    if flavour == 'tensorflow':
+    if flavour == Framework.TENSORFLOW:
         model = load_model_tf(src, load_dir='.', custom_objects=custom_obj, layer=layer)
-    elif flavour == 'sklearn':
+    elif flavour == Framework.SKLEARN:
         model = load_model_sk(src)
     else:
         raise NotImplementedError('Loading of PyTorch models not currently supported')
@@ -291,7 +291,7 @@ def _load_embedding_config(cfg: dict) -> Callable:  # TODO: Could type return mo
     layers = cfg['layers']
     typ = cfg['type']
     flavour = cfg['flavour']
-    if flavour == 'tensorflow':
+    if flavour == Framework.TENSORFLOW:
         emb = load_embedding_tf(src, embedding_type=typ, layers=layers)
     else:
         raise NotImplementedError('Loading of non-tensorflow embedding models not currently supported')
@@ -335,7 +335,7 @@ def _load_optimizer_config(cfg: dict,
     -------
     The loaded optimizer.
     """
-    if backend == 'tensorflow':
+    if backend == Framework.TENSORFLOW:
         optimizer = load_optimizer_tf(cfg)
     else:
         raise NotImplementedError('Loading of non-tensorflow optimizers not currently supported')
@@ -493,7 +493,7 @@ def resolve_config(cfg: dict, config_dir: Optional[Path]) -> dict:
         # are not resolved into objects here, since they are yet to undergo a further validation step). Instead, only
         # their components, such as `src`, are resolved above.
         elif isinstance(src, dict):
-            backend = cfg.get('backend', 'tensorflow')
+            backend = cfg.get('backend', Framework.TENSORFLOW)
             if key[-1] in ('model', 'proj'):
                 obj = _load_model_config(src)
             elif key[-1] == 'embedding':

--- a/alibi_detect/saving/saving.py
+++ b/alibi_detect/saving/saving.py
@@ -13,7 +13,7 @@ from transformers import PreTrainedTokenizerBase
 from alibi_detect.saving._typing import VALID_DETECTORS
 from alibi_detect.saving.loading import _replace, validate_config
 from alibi_detect.saving.registry import registry
-from alibi_detect.saving.schemas import SupportedModels, SupportedModels_tf, SupportedModels_sklearn
+from alibi_detect.utils._types import supported_models_all, supported_models_tf, supported_models_sklearn
 from alibi_detect.base import Detector, ConfigurableDetector
 from alibi_detect.saving._tensorflow import save_detector_legacy, save_model_config_tf
 from alibi_detect.saving._sklearn import save_model_config_sk
@@ -264,7 +264,7 @@ def _save_preprocess_config(preprocess_fn: Callable,
     kwargs = {}
     for k, v in func_kwargs.items():
         # Model/embedding
-        if isinstance(v, SupportedModels):
+        if isinstance(v, supported_models_all):
             cfg_model, cfg_embed = _save_model_config(v, filepath, input_shape, local_path)
             kwargs.update({k: cfg_model})
             if cfg_embed is not None:
@@ -411,9 +411,9 @@ def _save_model_config(model: Any,
     -------
     A tuple containing the model and embedding config dicts.
     """
-    if isinstance(model, SupportedModels_tf):
+    if isinstance(model, supported_models_tf):
         return save_model_config_tf(model, base_path, input_shape, path)
-    elif isinstance(model, SupportedModels_sklearn):
+    elif isinstance(model, supported_models_sklearn):
         return save_model_config_sk(model, base_path, path), None
     else:
         raise NotImplementedError("Support for saving the given model is not yet implemented")

--- a/alibi_detect/saving/saving.py
+++ b/alibi_detect/saving/saving.py
@@ -14,6 +14,7 @@ from alibi_detect.saving._typing import VALID_DETECTORS
 from alibi_detect.saving.loading import _replace, validate_config
 from alibi_detect.saving.registry import registry
 from alibi_detect.utils._types import supported_models_all, supported_models_tf, supported_models_sklearn
+from alibi_detect.utils.frameworks import Framework
 from alibi_detect.base import Detector, ConfigurableDetector
 from alibi_detect.saving._tensorflow import save_detector_legacy, save_model_config_tf
 from alibi_detect.saving._sklearn import save_model_config_sk
@@ -47,7 +48,7 @@ def save_detector(
     if legacy:
         warnings.warn('The `legacy` option will be removed in a future version.', DeprecationWarning)
 
-    if 'backend' in list(detector.meta.keys()) and detector.meta['backend'] in ['pytorch', 'keops']:
+    if 'backend' in list(detector.meta.keys()) and detector.meta['backend'] in [Framework.PYTORCH, Framework.KEOPS]:
         raise NotImplementedError('Saving detectors with pytorch or keops backend is not yet supported.')
 
     # TODO: Replace .__args__ w/ typing.get_args() once Python 3.7 dropped (and remove type ignore below)
@@ -125,7 +126,7 @@ def _save_detector_config(detector: ConfigurableDetector, filepath: Union[str, o
     """
     # Get backend, input_shape and detector_name
     backend = detector.meta.get('backend', None)
-    if backend not in (None, 'tensorflow', 'sklearn'):
+    if backend not in (None, Framework.TENSORFLOW, Framework.SKLEARN):
         raise NotImplementedError("Currently, saving is only supported with backend='tensorflow' and 'sklearn'.")
     detector_name = detector.__class__.__name__
 

--- a/alibi_detect/saving/schemas.py
+++ b/alibi_detect/saving/schemas.py
@@ -141,7 +141,7 @@ class ModelConfig(CustomBaseModel):
         src = "model/"
         layer = -1
     """
-    flavour: Literal[Framework.TENSORFLOW, Framework.PYTORCH, Framework.SKLEARN]
+    flavour: Literal['tensorflow', 'pytorch', 'sklearn']
     """
     Whether the model is a `tensorflow`, `pytorch` or `sklearn` model. XGBoost models following the scikit-learn API
     are also included under `sklearn`.
@@ -185,7 +185,7 @@ class EmbeddingConfig(CustomBaseModel):
         type = "hidden_state"
         layers = [-1, -2, -3, -4, -5, -6, -7, -8]
     """
-    flavour: Literal[Framework.TENSORFLOW, Framework.PYTORCH] = Framework.TENSORFLOW
+    flavour: Literal['tensorflow', 'pytorch'] = 'tensorflow'
     """
     Whether the embedding model is a `tensorflow` or `pytorch` model.
     """
@@ -659,7 +659,7 @@ class MMDDriftConfig(DriftDetectorConfig):
     Except for the `name` and `meta` fields, the fields match the detector's args and kwargs. Refer to the
     :class:`~alibi_detect.cd.MMDDrift` documentation for a description of each field.
     """
-    backend: Literal[Framework.TENSORFLOW, Framework.PYTORCH, Framework.SKLEARN]
+    backend: Literal['tensorflow', 'pytorch', 'keops'] = 'tensorflow'
     p_val: float = .05
     preprocess_at_init: bool = True
     update_x_ref: Optional[Dict[str, int]] = None
@@ -679,7 +679,7 @@ class MMDDriftConfigResolved(DriftDetectorConfigResolved):
     Except for the `name` and `meta` fields, the fields match the detector's args and kwargs. Refer to the
     :class:`~alibi_detect.cd.MMDDrift` documentation for a description of each field.
     """
-    backend: Literal[Framework.TENSORFLOW, Framework.PYTORCH, Framework.KEOPS] = Framework.TENSORFLOW
+    backend: Literal['tensorflow', 'pytorch', 'keops'] = 'tensorflow'
     p_val: float = .05
     preprocess_at_init: bool = True
     update_x_ref: Optional[Dict[str, int]] = None
@@ -699,7 +699,7 @@ class LSDDDriftConfig(DriftDetectorConfig):
     Except for the `name` and `meta` fields, the fields match the detector's args and kwargs. Refer to the
     :class:`~alibi_detect.cd.LSDDDrift` documentation for a description of each field.
     """
-    backend: Literal[Framework.TENSORFLOW, Framework.PYTORCH] = Framework.TENSORFLOW
+    backend: Literal['tensorflow', 'pytorch'] = 'tensorflow'
     p_val: float = .05
     preprocess_at_init: bool = True
     update_x_ref: Optional[Dict[str, int]] = None
@@ -718,7 +718,7 @@ class LSDDDriftConfigResolved(DriftDetectorConfigResolved):
     Except for the `name` and `meta` fields, the fields match the detector's args and kwargs. Refer to the
     :class:`~alibi_detect.cd.LSDDDrift` documentation for a description of each field.
     """
-    backend: Literal[Framework.TENSORFLOW, Framework.PYTORCH] = Framework.TENSORFLOW
+    backend: Literal['tensorflow', 'pytorch'] = 'tensorflow'
     p_val: float = .05
     preprocess_at_init: bool = True
     update_x_ref: Optional[Dict[str, int]] = None
@@ -738,7 +738,7 @@ class ClassifierDriftConfig(DriftDetectorConfig):
     Except for the `name` and `meta` fields, the fields match the detector's args and kwargs. Refer to the
     :class:`~alibi_detect.cd.ClassifierDrift` documentation for a description of each field.
     """
-    backend: Literal[Framework.TENSORFLOW, Framework.PYTORCH, Framework.SKLEARN] = Framework.TENSORFLOW
+    backend: Literal['tensorflow', 'pytorch', 'sklearn'] = 'tensorflow'
     p_val: float = .05
     preprocess_at_init: bool = True
     update_x_ref: Optional[Dict[str, int]] = None
@@ -774,7 +774,7 @@ class ClassifierDriftConfigResolved(DriftDetectorConfigResolved):
     Except for the `name` and `meta` fields, the fields match the detector's args and kwargs. Refer to the
     :class:`~alibi_detect.cd.ClassifierDrift` documentation for a description of each field.
     """
-    backend: Literal[Framework.TENSORFLOW, Framework.PYTORCH, Framework.SKLEARN] = Framework.TENSORFLOW
+    backend: Literal['tensorflow', 'pytorch', 'sklearn'] = 'tensorflow'
     p_val: float = .05
     preprocess_at_init: bool = True
     update_x_ref: Optional[Dict[str, int]] = None
@@ -810,7 +810,7 @@ class SpotTheDiffDriftConfig(DriftDetectorConfig):
     Except for the `name` and `meta` fields, the fields match the detector's args and kwargs. Refer to the
     :class:`~alibi_detect.cd.SpotTheDiffDrift` documentation for a description of each field.
     """
-    backend: Literal[Framework.TENSORFLOW, Framework.PYTORCH] = Framework.TENSORFLOW
+    backend: Literal['tensorflow', 'pytorch'] = 'tensorflow'
     p_val: float = .05
     binarize_preds: bool = False
     train_size: Optional[float] = .75
@@ -842,7 +842,7 @@ class SpotTheDiffDriftConfigResolved(DriftDetectorConfigResolved):
     Except for the `name` and `meta` fields, the fields match the detector's args and kwargs. Refer to the
     :class:`~alibi_detect.cd.SpotTheDiffDrift` documentation for a description of each field.
     """
-    backend: Literal[Framework.TENSORFLOW, Framework.PYTORCH] = Framework.TENSORFLOW
+    backend: Literal['tensorflow', 'pytorch'] = 'tensorflow'
     p_val: float = .05
     binarize_preds: bool = False
     train_size: Optional[float] = .75
@@ -874,7 +874,7 @@ class LearnedKernelDriftConfig(DriftDetectorConfig):
     Except for the `name` and `meta` fields, the fields match the detector's args and kwargs. Refer to the
     :class:`~alibi_detect.cd.LearnedKernelDrift` documentation for a description of each field.
     """
-    backend: Literal[Framework.TENSORFLOW, Framework.PYTORCH, Framework.KEOPS] = Framework.TENSORFLOW
+    backend: Literal['tensorflow', 'pytorch', 'keops'] = 'tensorflow'
     p_val: float = .05
     kernel: Union[str, DeepKernelConfig]
     preprocess_at_init: bool = True
@@ -907,7 +907,7 @@ class LearnedKernelDriftConfigResolved(DriftDetectorConfigResolved):
     Except for the `name` and `meta` fields, the fields match the detector's args and kwargs. Refer to the
     :class:`~alibi_detect.cd.LearnedKernelDrift` documentation for a description of each field.
     """
-    backend: Literal[Framework.TENSORFLOW, Framework.PYTORCH, Framework.KEOPS] = Framework.TENSORFLOW
+    backend: Literal['tensorflow', 'pytorch', 'keops'] = 'tensorflow'
     p_val: float = .05
     kernel: Optional[Callable] = None
     preprocess_at_init: bool = True
@@ -940,7 +940,7 @@ class ContextMMDDriftConfig(DriftDetectorConfig):
     Except for the `name` and `meta` fields, the fields match the detector's args and kwargs. Refer to the
     :class:`~alibi_detect.cd.ContextMMDDrift` documentation for a description of each field.
     """
-    backend: Literal[Framework.TENSORFLOW, Framework.PYTORCH] = Framework.TENSORFLOW
+    backend: Literal['tensorflow', 'pytorch'] = 'tensorflow'
     p_val: float = .05
     c_ref: str
     preprocess_at_init: bool = True
@@ -963,7 +963,7 @@ class ContextMMDDriftConfigResolved(DriftDetectorConfigResolved):
     Except for the `name` and `meta` fields, the fields match the detector's args and kwargs. Refer to the
     :class:`~alibi_detect.cd.MMDDrift` documentation for a description of each field.
     """
-    backend: Literal[Framework.TENSORFLOW, Framework.PYTORCH] = Framework.TENSORFLOW
+    backend: Literal['tensorflow', 'pytorch'] = 'tensorflow'
     p_val: float = .05
     c_ref: np.ndarray
     preprocess_at_init: bool = True
@@ -987,7 +987,7 @@ class MMDDriftOnlineConfig(DriftDetectorConfig):
     Except for the `name` and `meta` fields, the fields match the detector's args and kwargs. Refer to the
     :class:`~alibi_detect.cd.MMDDriftOnline` documentation for a description of each field.
     """
-    backend: Literal[Framework.TENSORFLOW, Framework.PYTORCH] = Framework.TENSORFLOW
+    backend: Literal['tensorflow', 'pytorch'] = 'tensorflow'
     ert: float
     window_size: int
     kernel: Optional[Union[str, KernelConfig]] = None
@@ -1006,7 +1006,7 @@ class MMDDriftOnlineConfigResolved(DriftDetectorConfigResolved):
     Except for the `name` and `meta` fields, the fields match the detector's args and kwargs. Refer to the
     :class:`~alibi_detect.cd.MMDDriftOnline` documentation for a description of each field.
     """
-    backend: Literal[Framework.TENSORFLOW, Framework.PYTORCH] = Framework.TENSORFLOW
+    backend: Literal['tensorflow', 'pytorch'] = 'tensorflow'
     ert: float
     window_size: int
     kernel: Optional[Callable] = None
@@ -1025,7 +1025,7 @@ class LSDDDriftOnlineConfig(DriftDetectorConfig):
     Except for the `name` and `meta` fields, the fields match the detector's args and kwargs. Refer to the
     :class:`~alibi_detect.cd.LSDDDriftOnline` documentation for a description of each field.
     """
-    backend: Literal[Framework.TENSORFLOW, Framework.PYTORCH] = Framework.TENSORFLOW
+    backend: Literal['tensorflow', 'pytorch'] = 'tensorflow'
     ert: float
     window_size: int
     sigma: Optional[np.ndarray] = None
@@ -1045,7 +1045,7 @@ class LSDDDriftOnlineConfigResolved(DriftDetectorConfigResolved):
     Except for the `name` and `meta` fields, the fields match the detector's args and kwargs. Refer to the
     :class:`~alibi_detect.cd.LSDDDriftOnline` documentation for a description of each field.
     """
-    backend: Literal[Framework.TENSORFLOW, Framework.PYTORCH] = Framework.TENSORFLOW
+    backend: Literal['tensorflow', 'pytorch'] = 'tensorflow'
     ert: float
     window_size: int
     sigma: Optional[np.ndarray] = None
@@ -1151,7 +1151,7 @@ class ClassifierUncertaintyDriftConfig(DetectorConfig):
     Except for the `name` and `meta` fields, the fields match the detector's args and kwargs. Refer to the
     :class:`~alibi_detect.cd.ClassifierUncertaintyDrift` documentation for a description of each field.
     """
-    backend: Literal[Framework.TENSORFLOW, Framework.PYTORCH] = Framework.TENSORFLOW
+    backend: Literal['tensorflow', 'pytorch'] = 'tensorflow'
     x_ref: str
     model: Union[str, ModelConfig]
     p_val: float = .05
@@ -1178,7 +1178,7 @@ class ClassifierUncertaintyDriftConfigResolved(DetectorConfig):
     Except for the `name` and `meta` fields, the fields match the detector's args and kwargs. Refer to the
     :class:`~alibi_detect.cd.ClassifierUncertaintyDrift` documentation for a description of each field.
     """
-    backend: Literal[Framework.TENSORFLOW, Framework.PYTORCH] = Framework.TENSORFLOW
+    backend: Literal['tensorflow', 'pytorch'] = 'tensorflow'
     x_ref: Union[np.ndarray, list]
     model: Optional[SupportedModels] = None
     p_val: float = .05
@@ -1205,7 +1205,7 @@ class RegressorUncertaintyDriftConfig(DetectorConfig):
     Except for the `name` and `meta` fields, the fields match the detector's args and kwargs. Refer to the
     :class:`~alibi_detect.cd.RegressorUncertaintyDrift` documentation for a description of each field.
     """
-    backend: Literal[Framework.TENSORFLOW, Framework.PYTORCH] = Framework.TENSORFLOW
+    backend: Literal['tensorflow', 'pytorch'] = 'tensorflow'
     x_ref: str
     model: Union[str, ModelConfig]
     p_val: float = .05
@@ -1231,7 +1231,7 @@ class RegressorUncertaintyDriftConfigResolved(DetectorConfig):
     Except for the `name` and `meta` fields, the fields match the detector's args and kwargs. Refer to the
     :class:`~alibi_detect.cd.RegressorUncertaintyDrift` documentation for a description of each field.
     """
-    backend: Literal[Framework.TENSORFLOW, Framework.PYTORCH] = Framework.TENSORFLOW
+    backend: Literal['tensorflow', 'pytorch'] = 'tensorflow'
     x_ref: Union[np.ndarray, list]
     model: Optional[SupportedModels] = None
     p_val: float = .05

--- a/alibi_detect/saving/schemas.py
+++ b/alibi_detect/saving/schemas.py
@@ -19,6 +19,7 @@ from typing import Callable, Dict, List, Optional, Type, Union, Any
 import numpy as np
 from pydantic import BaseModel, validator
 
+from alibi_detect.utils.frameworks import Framework
 from alibi_detect.utils._types import (Literal, NDArray, supported_models_all, supported_models_tf,
                                        supported_models_sklearn, supported_models_torch, supported_optimizers_tf,
                                        supported_optimizers_torch, supported_optimizers_all)
@@ -45,14 +46,14 @@ class SupportedModels:
     @classmethod
     def validate_model(cls, model: Any, values: dict) -> Any:
         backend = values['backend']
-        if backend == 'tensorflow' and not isinstance(model, supported_models_tf):
-            raise TypeError("`backend='tensorflow'` but the `model` doesn't appear to be a TensorFlow supported model, "
-                            "or TensorFlow is not installed.")
-        elif backend == 'pytorch' and not isinstance(model, supported_models_torch):
-            raise TypeError("`backend='pytorch'` but the `model` doesn't appear to be a TensorFlow supported model, "
-                            "or PyTorch is not installed.")
-        elif backend == 'sklearn' and not isinstance(model, supported_models_sklearn):
-            raise TypeError("`backend='sklearn'` but the `model` doesn't appear to be a scikit-learn supported model.")
+        err_msg = f"`backend={backend}` but the `model` doesn't appear to be a {backend} supported model, "\
+                  f"or {backend} is not installed."
+        if backend == Framework.TENSORFLOW and not isinstance(model, supported_models_tf):
+            raise TypeError(err_msg)
+        elif backend == Framework.PYTORCH and not isinstance(model, supported_models_torch):
+            raise TypeError(err_msg)
+        elif backend == Framework.SKLEARN and not isinstance(model, supported_models_sklearn):
+            raise TypeError(f"`backend={backend}` but the `model` doesn't appear to be a {backend} supported model.")
         elif isinstance(model, supported_models_all):  # If model supported and no `backend` incompatibility
             return model
         else:  # Catch any other unexpected issues
@@ -71,12 +72,12 @@ class SupportedOptimizers:
     @classmethod
     def validate_optimizer(cls, optimizer: Any, values: dict) -> Any:
         backend = values['backend']
-        if backend == 'tensorflow' and not isinstance(optimizer, supported_optimizers_tf):
-            raise TypeError("`backend='tensorflow'` but the `optimizer` doesn't appear to be a TensorFlow supported "
-                            "optimizer, or TensorFlow is not installed.")
-        elif backend == 'pytorch' and not isinstance(optimizer, supported_optimizers_torch):
-            raise TypeError("`backend='pytorch'` but the `optimizer` doesn't appear to be a TensorFlow supported"
-                            "optimizer, or PyTorch is not installed.")
+        err_msg = f"`backend={backend}` but the `optimizer` doesn't appear to be a {backend} supported model, "\
+                  f"or {backend} is not installed."
+        if backend == Framework.TENSORFLOW and not isinstance(optimizer, supported_optimizers_tf):
+            raise TypeError(err_msg)
+        elif backend == Framework.PYTORCH and not isinstance(optimizer, supported_optimizers_torch):
+            raise TypeError(err_msg)
         elif isinstance(optimizer, supported_optimizers_all):  # If optimizer supported and no `backend` incompatibility
             return optimizer
         else:  # Catch any other unexpected issues
@@ -140,7 +141,7 @@ class ModelConfig(CustomBaseModel):
         src = "model/"
         layer = -1
     """
-    flavour: Literal['tensorflow', 'pytorch', 'sklearn']
+    flavour: Literal[Framework.TENSORFLOW, Framework.PYTORCH, Framework.SKLEARN]
     """
     Whether the model is a `tensorflow`, `pytorch` or `sklearn` model. XGBoost models following the scikit-learn API
     are also included under `sklearn`.
@@ -184,7 +185,7 @@ class EmbeddingConfig(CustomBaseModel):
         type = "hidden_state"
         layers = [-1, -2, -3, -4, -5, -6, -7, -8]
     """
-    flavour: Literal['tensorflow', 'pytorch'] = 'tensorflow'
+    flavour: Literal[Framework.TENSORFLOW, Framework.PYTORCH] = Framework.TENSORFLOW
     """
     Whether the embedding model is a `tensorflow` or `pytorch` model.
     """
@@ -658,7 +659,7 @@ class MMDDriftConfig(DriftDetectorConfig):
     Except for the `name` and `meta` fields, the fields match the detector's args and kwargs. Refer to the
     :class:`~alibi_detect.cd.MMDDrift` documentation for a description of each field.
     """
-    backend: Literal['tensorflow', 'pytorch', 'keops'] = 'tensorflow'
+    backend: Literal[Framework.TENSORFLOW, Framework.PYTORCH, Framework.SKLEARN]
     p_val: float = .05
     preprocess_at_init: bool = True
     update_x_ref: Optional[Dict[str, int]] = None
@@ -678,7 +679,7 @@ class MMDDriftConfigResolved(DriftDetectorConfigResolved):
     Except for the `name` and `meta` fields, the fields match the detector's args and kwargs. Refer to the
     :class:`~alibi_detect.cd.MMDDrift` documentation for a description of each field.
     """
-    backend: Literal['tensorflow', 'pytorch', 'keops'] = 'tensorflow'
+    backend: Literal[Framework.TENSORFLOW, Framework.PYTORCH, Framework.KEOPS] = Framework.TENSORFLOW
     p_val: float = .05
     preprocess_at_init: bool = True
     update_x_ref: Optional[Dict[str, int]] = None
@@ -698,7 +699,7 @@ class LSDDDriftConfig(DriftDetectorConfig):
     Except for the `name` and `meta` fields, the fields match the detector's args and kwargs. Refer to the
     :class:`~alibi_detect.cd.LSDDDrift` documentation for a description of each field.
     """
-    backend: Literal['tensorflow', 'pytorch'] = 'tensorflow'
+    backend: Literal[Framework.TENSORFLOW, Framework.PYTORCH] = Framework.TENSORFLOW
     p_val: float = .05
     preprocess_at_init: bool = True
     update_x_ref: Optional[Dict[str, int]] = None
@@ -717,7 +718,7 @@ class LSDDDriftConfigResolved(DriftDetectorConfigResolved):
     Except for the `name` and `meta` fields, the fields match the detector's args and kwargs. Refer to the
     :class:`~alibi_detect.cd.LSDDDrift` documentation for a description of each field.
     """
-    backend: Literal['tensorflow', 'pytorch'] = 'tensorflow'
+    backend: Literal[Framework.TENSORFLOW, Framework.PYTORCH] = Framework.TENSORFLOW
     p_val: float = .05
     preprocess_at_init: bool = True
     update_x_ref: Optional[Dict[str, int]] = None
@@ -737,7 +738,7 @@ class ClassifierDriftConfig(DriftDetectorConfig):
     Except for the `name` and `meta` fields, the fields match the detector's args and kwargs. Refer to the
     :class:`~alibi_detect.cd.ClassifierDrift` documentation for a description of each field.
     """
-    backend: Literal['tensorflow', 'pytorch', 'sklearn'] = 'tensorflow'
+    backend: Literal[Framework.TENSORFLOW, Framework.PYTORCH, Framework.SKLEARN] = Framework.TENSORFLOW
     p_val: float = .05
     preprocess_at_init: bool = True
     update_x_ref: Optional[Dict[str, int]] = None
@@ -773,7 +774,7 @@ class ClassifierDriftConfigResolved(DriftDetectorConfigResolved):
     Except for the `name` and `meta` fields, the fields match the detector's args and kwargs. Refer to the
     :class:`~alibi_detect.cd.ClassifierDrift` documentation for a description of each field.
     """
-    backend: Literal['tensorflow', 'pytorch', 'sklearn'] = 'tensorflow'
+    backend: Literal[Framework.TENSORFLOW, Framework.PYTORCH, Framework.SKLEARN] = Framework.TENSORFLOW
     p_val: float = .05
     preprocess_at_init: bool = True
     update_x_ref: Optional[Dict[str, int]] = None
@@ -809,7 +810,7 @@ class SpotTheDiffDriftConfig(DriftDetectorConfig):
     Except for the `name` and `meta` fields, the fields match the detector's args and kwargs. Refer to the
     :class:`~alibi_detect.cd.SpotTheDiffDrift` documentation for a description of each field.
     """
-    backend: Literal['tensorflow', 'pytorch'] = 'tensorflow'
+    backend: Literal[Framework.TENSORFLOW, Framework.PYTORCH] = Framework.TENSORFLOW
     p_val: float = .05
     binarize_preds: bool = False
     train_size: Optional[float] = .75
@@ -841,7 +842,7 @@ class SpotTheDiffDriftConfigResolved(DriftDetectorConfigResolved):
     Except for the `name` and `meta` fields, the fields match the detector's args and kwargs. Refer to the
     :class:`~alibi_detect.cd.SpotTheDiffDrift` documentation for a description of each field.
     """
-    backend: Literal['tensorflow', 'pytorch'] = 'tensorflow'
+    backend: Literal[Framework.TENSORFLOW, Framework.PYTORCH] = Framework.TENSORFLOW
     p_val: float = .05
     binarize_preds: bool = False
     train_size: Optional[float] = .75
@@ -873,7 +874,7 @@ class LearnedKernelDriftConfig(DriftDetectorConfig):
     Except for the `name` and `meta` fields, the fields match the detector's args and kwargs. Refer to the
     :class:`~alibi_detect.cd.LearnedKernelDrift` documentation for a description of each field.
     """
-    backend: Literal['tensorflow', 'pytorch', 'keops'] = 'tensorflow'
+    backend: Literal[Framework.TENSORFLOW, Framework.PYTORCH, Framework.KEOPS] = Framework.TENSORFLOW
     p_val: float = .05
     kernel: Union[str, DeepKernelConfig]
     preprocess_at_init: bool = True
@@ -906,7 +907,7 @@ class LearnedKernelDriftConfigResolved(DriftDetectorConfigResolved):
     Except for the `name` and `meta` fields, the fields match the detector's args and kwargs. Refer to the
     :class:`~alibi_detect.cd.LearnedKernelDrift` documentation for a description of each field.
     """
-    backend: Literal['tensorflow', 'pytorch', 'keops'] = 'tensorflow'
+    backend: Literal[Framework.TENSORFLOW, Framework.PYTORCH, Framework.KEOPS] = Framework.TENSORFLOW
     p_val: float = .05
     kernel: Optional[Callable] = None
     preprocess_at_init: bool = True
@@ -939,7 +940,7 @@ class ContextMMDDriftConfig(DriftDetectorConfig):
     Except for the `name` and `meta` fields, the fields match the detector's args and kwargs. Refer to the
     :class:`~alibi_detect.cd.ContextMMDDrift` documentation for a description of each field.
     """
-    backend: Literal['tensorflow', 'pytorch'] = 'tensorflow'
+    backend: Literal[Framework.TENSORFLOW, Framework.PYTORCH] = Framework.TENSORFLOW
     p_val: float = .05
     c_ref: str
     preprocess_at_init: bool = True
@@ -962,7 +963,7 @@ class ContextMMDDriftConfigResolved(DriftDetectorConfigResolved):
     Except for the `name` and `meta` fields, the fields match the detector's args and kwargs. Refer to the
     :class:`~alibi_detect.cd.MMDDrift` documentation for a description of each field.
     """
-    backend: Literal['tensorflow', 'pytorch'] = 'tensorflow'
+    backend: Literal[Framework.TENSORFLOW, Framework.PYTORCH] = Framework.TENSORFLOW
     p_val: float = .05
     c_ref: np.ndarray
     preprocess_at_init: bool = True
@@ -986,7 +987,7 @@ class MMDDriftOnlineConfig(DriftDetectorConfig):
     Except for the `name` and `meta` fields, the fields match the detector's args and kwargs. Refer to the
     :class:`~alibi_detect.cd.MMDDriftOnline` documentation for a description of each field.
     """
-    backend: Literal['tensorflow', 'pytorch'] = 'tensorflow'
+    backend: Literal[Framework.TENSORFLOW, Framework.PYTORCH] = Framework.TENSORFLOW
     ert: float
     window_size: int
     kernel: Optional[Union[str, KernelConfig]] = None
@@ -1005,7 +1006,7 @@ class MMDDriftOnlineConfigResolved(DriftDetectorConfigResolved):
     Except for the `name` and `meta` fields, the fields match the detector's args and kwargs. Refer to the
     :class:`~alibi_detect.cd.MMDDriftOnline` documentation for a description of each field.
     """
-    backend: Literal['tensorflow', 'pytorch'] = 'tensorflow'
+    backend: Literal[Framework.TENSORFLOW, Framework.PYTORCH] = Framework.TENSORFLOW
     ert: float
     window_size: int
     kernel: Optional[Callable] = None
@@ -1024,7 +1025,7 @@ class LSDDDriftOnlineConfig(DriftDetectorConfig):
     Except for the `name` and `meta` fields, the fields match the detector's args and kwargs. Refer to the
     :class:`~alibi_detect.cd.LSDDDriftOnline` documentation for a description of each field.
     """
-    backend: Literal['tensorflow', 'pytorch'] = 'tensorflow'
+    backend: Literal[Framework.TENSORFLOW, Framework.PYTORCH] = Framework.TENSORFLOW
     ert: float
     window_size: int
     sigma: Optional[np.ndarray] = None
@@ -1044,7 +1045,7 @@ class LSDDDriftOnlineConfigResolved(DriftDetectorConfigResolved):
     Except for the `name` and `meta` fields, the fields match the detector's args and kwargs. Refer to the
     :class:`~alibi_detect.cd.LSDDDriftOnline` documentation for a description of each field.
     """
-    backend: Literal['tensorflow', 'pytorch'] = 'tensorflow'
+    backend: Literal[Framework.TENSORFLOW, Framework.PYTORCH] = Framework.TENSORFLOW
     ert: float
     window_size: int
     sigma: Optional[np.ndarray] = None
@@ -1150,7 +1151,7 @@ class ClassifierUncertaintyDriftConfig(DetectorConfig):
     Except for the `name` and `meta` fields, the fields match the detector's args and kwargs. Refer to the
     :class:`~alibi_detect.cd.ClassifierUncertaintyDrift` documentation for a description of each field.
     """
-    backend: Literal['tensorflow', 'pytorch'] = 'tensorflow'
+    backend: Literal[Framework.TENSORFLOW, Framework.PYTORCH] = Framework.TENSORFLOW
     x_ref: str
     model: Union[str, ModelConfig]
     p_val: float = .05
@@ -1177,7 +1178,7 @@ class ClassifierUncertaintyDriftConfigResolved(DetectorConfig):
     Except for the `name` and `meta` fields, the fields match the detector's args and kwargs. Refer to the
     :class:`~alibi_detect.cd.ClassifierUncertaintyDrift` documentation for a description of each field.
     """
-    backend: Literal['tensorflow', 'pytorch'] = 'tensorflow'
+    backend: Literal[Framework.TENSORFLOW, Framework.PYTORCH] = Framework.TENSORFLOW
     x_ref: Union[np.ndarray, list]
     model: Optional[SupportedModels] = None
     p_val: float = .05
@@ -1204,7 +1205,7 @@ class RegressorUncertaintyDriftConfig(DetectorConfig):
     Except for the `name` and `meta` fields, the fields match the detector's args and kwargs. Refer to the
     :class:`~alibi_detect.cd.RegressorUncertaintyDrift` documentation for a description of each field.
     """
-    backend: Literal['tensorflow', 'pytorch'] = 'tensorflow'
+    backend: Literal[Framework.TENSORFLOW, Framework.PYTORCH] = Framework.TENSORFLOW
     x_ref: str
     model: Union[str, ModelConfig]
     p_val: float = .05
@@ -1230,7 +1231,7 @@ class RegressorUncertaintyDriftConfigResolved(DetectorConfig):
     Except for the `name` and `meta` fields, the fields match the detector's args and kwargs. Refer to the
     :class:`~alibi_detect.cd.RegressorUncertaintyDrift` documentation for a description of each field.
     """
-    backend: Literal['tensorflow', 'pytorch'] = 'tensorflow'
+    backend: Literal[Framework.TENSORFLOW, Framework.PYTORCH] = Framework.TENSORFLOW
     x_ref: Union[np.ndarray, list]
     model: Optional[SupportedModels] = None
     p_val: float = .05

--- a/alibi_detect/saving/schemas.py
+++ b/alibi_detect/saving/schemas.py
@@ -13,7 +13,6 @@ The `resolved` kwarg of :func:`~alibi_detect.utils.validate.validate_config` det
     For detector pydantic models, the fields match the corresponding detector's args/kwargs. Refer to the
     detector's api docs for a full description of each arg/kwarg.
 """
-from __future__ import annotations
 from typing import Callable, Dict, List, Optional, Type, Union, Any
 
 import numpy as np
@@ -34,7 +33,7 @@ def coerce_int2list(value: int) -> List[int]:
         return value
 
 
-class SupportedModels:
+class SupportedModel:
     """
     Pydantic custom type to check the model is one of the supported types (conditional on what optional deps
     are installed).
@@ -60,7 +59,7 @@ class SupportedModels:
             raise TypeError('The model is not recognised as a supported type.')
 
 
-class SupportedOptimizers:
+class SupportedOptimizer:
     """
     Pydantic custom type to check the optimizer is one of the supported types (conditional on what optional deps
     are installed).
@@ -778,7 +777,7 @@ class ClassifierDriftConfigResolved(DriftDetectorConfigResolved):
     p_val: float = .05
     preprocess_at_init: bool = True
     update_x_ref: Optional[Dict[str, int]] = None
-    model: Optional[SupportedModels] = None
+    model: Optional[SupportedModel] = None
     preds_type: Literal['probs', 'logits'] = 'probs'
     binarize_preds: bool = False
     reg_loss_fn: Optional[Callable] = None
@@ -786,7 +785,7 @@ class ClassifierDriftConfigResolved(DriftDetectorConfigResolved):
     n_folds: Optional[int] = None
     retrain_from_scratch: bool = True
     seed: int = 0
-    optimizer: Optional[SupportedOptimizers] = None
+    optimizer: Optional[SupportedOptimizer] = None
     learning_rate: float = 1e-3
     batch_size: int = 32
     preprocess_batch_fn: Optional[Callable] = None
@@ -849,7 +848,7 @@ class SpotTheDiffDriftConfigResolved(DriftDetectorConfigResolved):
     n_folds: Optional[int] = None
     retrain_from_scratch: bool = True
     seed: int = 0
-    optimizer: Optional[OptimizerConfig] = None
+    optimizer: Optional[SupportedOptimizer] = None
     learning_rate: float = 1e-3
     batch_size: int = 32
     preprocess_batch_fn: Optional[Callable] = None
@@ -918,7 +917,7 @@ class LearnedKernelDriftConfigResolved(DriftDetectorConfigResolved):
     reg_loss_fn: Optional[Callable] = None
     train_size: Optional[float] = .75
     retrain_from_scratch: bool = True
-    optimizer: Optional[OptimizerConfig] = None
+    optimizer: Optional[SupportedOptimizer] = None
     learning_rate: float = 1e-3
     batch_size: int = 32
     batch_size_predict: int = 1000000
@@ -1180,7 +1179,7 @@ class ClassifierUncertaintyDriftConfigResolved(DetectorConfig):
     """
     backend: Literal['tensorflow', 'pytorch'] = 'tensorflow'
     x_ref: Union[np.ndarray, list]
-    model: Optional[SupportedModels] = None
+    model: Optional[SupportedModel] = None
     p_val: float = .05
     x_ref_preprocessed: bool = False
     update_x_ref: Optional[Dict[str, int]] = None
@@ -1233,7 +1232,7 @@ class RegressorUncertaintyDriftConfigResolved(DetectorConfig):
     """
     backend: Literal['tensorflow', 'pytorch'] = 'tensorflow'
     x_ref: Union[np.ndarray, list]
-    model: Optional[SupportedModels] = None
+    model: Optional[SupportedModel] = None
     p_val: float = .05
     x_ref_preprocessed: bool = False
     update_x_ref: Optional[Dict[str, int]] = None

--- a/alibi_detect/saving/tests/test_validate.py
+++ b/alibi_detect/saving/tests/test_validate.py
@@ -14,7 +14,7 @@ mmd_cfg = {
     },
     'name': 'MMDDrift',
     'x_ref': np.array([[-0.30074928], [1.50240758], [0.43135768], [2.11295779], [0.79684913]]),
-    'p_val': 0.05
+    'p_val': 0.05,
 }
 
 # Define a detector config dict without meta (as simple as it gets!)

--- a/alibi_detect/utils/_types.py
+++ b/alibi_detect/utils/_types.py
@@ -2,7 +2,7 @@
 Defining types compatible with different Python versions and defining custom types.
 """
 import sys
-from typing import Any, Generic, Optional, Type, TypeVar, Union
+from typing import Any, Generic, Optional, Type, TypeVar
 import numpy as np
 from numpy.lib import NumpyVersion
 from pydantic.fields import ModelField
@@ -69,13 +69,3 @@ if has_pytorch:
 supported_models_sklearn = (BaseEstimator, )  # type: ignore
 supported_models_all = supported_models_tf + supported_models_torch + supported_models_sklearn
 supported_optimizers_all = supported_optimizers_tf + supported_optimizers_torch
-
-# 2. Type unions
-model_types_tf = Type['tf.keras.Model']
-model_types_torch = Union['torch.nn.Module', 'torch.nn.Sequential']
-model_types_sklearn = Type[BaseEstimator]  # no ForwardRef since sklearn a core dep
-optimizer_types_tf = Type['tf.keras.optimizers.Optimizer']
-optimizer_types_torch = Union['torch.optim.Optimizer']
-optimizer_types_sklearn = Type[BaseEstimator]  # no ForwardRef since sklearn a core dep
-model_types_all = Union[model_types_tf, model_types_torch, model_types_sklearn]
-optimizer_types_all = Union[optimizer_types_tf, optimizer_types_torch]

--- a/alibi_detect/utils/_types.py
+++ b/alibi_detect/utils/_types.py
@@ -55,11 +55,7 @@ def _validate(cls: Type, val: Any, field: ModelField) -> np.ndarray:
         return np.asarray(val)
 
 
-# Optional dep dependent type definitions. Two sets of items are defined here:
-# 1. Tuples of actual objects, conditional on installed ops deps, for use in isinstance()'s, including in pydantic.
-# 2. Type unions for type hints. Note: Not currently used properly by mypy since there are no stubs for tf, sklearn etc
-
-# 1. Tuples
+# Optional dep dependent tuples of types
 supported_models_tf, supported_models_torch, supported_models_sklearn = (), (), ()  # type: ignore
 supported_optimizers_tf, supported_optimizers_torch = (), ()  # type: ignore
 if has_tensorflow:

--- a/alibi_detect/utils/frameworks.py
+++ b/alibi_detect/utils/frameworks.py
@@ -1,5 +1,14 @@
 from .missing_optional_dependency import ERROR_TYPES
 from typing import Optional, List, Dict, Iterable
+from enum import Enum
+
+
+class Framework(str, Enum):
+    PYTORCH = 'pytorch'
+    TENSORFLOW = 'tensorflow'
+    KEOPS = 'keops'
+    SKLEARN = 'sklearn'
+
 
 try:
     import tensorflow as tf  # noqa

--- a/alibi_detect/utils/missing_optional_dependency.py
+++ b/alibi_detect/utils/missing_optional_dependency.py
@@ -9,6 +9,8 @@ functionality independent of the missing dependency.
 from typing import Union, List, Optional, Any
 from string import Template
 from importlib import import_module
+from alibi_detect.utils.frameworks import Framework
+
 
 err_msg_template = Template((
     "Attempted to use $object_name without the correct optional dependencies installed. To install "
@@ -30,12 +32,12 @@ dict is used to control two behaviours:
 """
 ERROR_TYPES = {
     "prophet": 'prophet',
-    "tensorflow_probability": 'tensorflow',
-    "tensorflow": 'tensorflow',
-    "torch": 'torch',
-    "pytorch": 'torch',
-    "keops": 'keops',
-    "pykeops": 'keops',
+    "tensorflow_probability": Framework.TENSORFLOW,
+    "tensorflow": Framework.TENSORFLOW,
+    "torch": Framework.PYTORCH,
+    "pytorch": Framework.PYTORCH,
+    "keops": Framework.KEOPS,
+    "pykeops": Framework.KEOPS,
 }
 
 

--- a/alibi_detect/utils/missing_optional_dependency.py
+++ b/alibi_detect/utils/missing_optional_dependency.py
@@ -9,8 +9,6 @@ functionality independent of the missing dependency.
 from typing import Union, List, Optional, Any
 from string import Template
 from importlib import import_module
-from alibi_detect.utils.frameworks import Framework
-
 
 err_msg_template = Template((
     "Attempted to use $object_name without the correct optional dependencies installed. To install "
@@ -32,12 +30,12 @@ dict is used to control two behaviours:
 """
 ERROR_TYPES = {
     "prophet": 'prophet',
-    "tensorflow_probability": Framework.TENSORFLOW,
-    "tensorflow": Framework.TENSORFLOW,
-    "torch": Framework.PYTORCH,
-    "pytorch": Framework.PYTORCH,
-    "keops": Framework.KEOPS,
-    "pykeops": Framework.KEOPS,
+    "tensorflow_probability": 'tensorflow',
+    "tensorflow": 'tensorflow',
+    "torch": 'torch',
+    "pytorch": 'torch',
+    "keops": 'keops',
+    "pykeops": 'keops',
 }
 
 


### PR DESCRIPTION
Minor follow-up PR to https://github.com/SeldonIO/alibi-detect/pull/642.

## Summary
Contains 3 main changes, and 1 requiring discussion (see **Outstanding**):
1. The backend frameworks (`'tensorflow'`, `'pytorch'` etc) are set via an `Enum` to avoid typo's, as discussed in https://github.com/SeldonIO/alibi-detect/pull/642#discussion_r990044848. Note, I haven't updated the tests to use this...
2. The old `SupportedModels_tf` etc defined in `saving.schemas.py` has been moved to `utils._types`, since it is more to do with typing than schemas specifically. It has also been renamed to `supported_models` since the camel case implied that these were classes, when in fact they are simply tuples of types. 
3. We had missed something when making TensorFlow an optional dependency. We still had ` optimizer: Optional['tf.keras.optimizers.Optimizer']` in some of the detector pydantic models. I think this would cause an error if the serialized detector was loaded when tensorflow isn't installed, since pydantic does not play nicely with forward refs. I've added the `SupportedOptimizers` custom pydantic data type to handle this in the same way `model`'s are handled.

## Outstanding

I investigated https://github.com/SeldonIO/alibi-detect/pull/642#discussion_r990039862. The issue here is that `SupportedModels` or similar pydantic data types cannot be used as type hints, since they are populated dynamically (conditional on installed optional deps), and mypy is a static type checker. For a simple solution, I have added `model_types_tf` etc for now for use in type hints. I won't update the rest of the code to use these until we have decided if these are a suitable solution.