### PR TITLE
Fixes for mypy 0.990

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
       - id: flake8
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.942
+    rev: v0.990
     hooks:
       - id: mypy
         additional_dependencies: [

--- a/alibi_detect/base.py
+++ b/alibi_detect/base.py
@@ -169,7 +169,7 @@ class DriftConfigMixin:
         name = self.__class__.__name__
 
         # Init config dict
-        self.config: Dict[str, Any] = {
+        self.config = {
             'name': name,
             'meta': {
                 'version': __version__,

--- a/alibi_detect/utils/keops/kernels.py
+++ b/alibi_detect/utils/keops/kernels.py
@@ -57,7 +57,7 @@ class GaussianRBF(nn.Module):
     def __init__(
         self,
         sigma: Optional[torch.Tensor] = None,
-        init_sigma_fn: Callable = None,
+        init_sigma_fn: Optional[Callable] = None,
         trainable: bool = False
     ) -> None:
         """


### PR DESCRIPTION
This PR addresses the following note and error that occur with mypy 0.990:

```
alibi_detect/base.py:172: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
alibi_detect/utils/keops/kernels.py:[8](https://github.com/SeldonIO/alibi-detect/actions/runs/3415204573/jobs/5684068907#step:7:9)4: error: Incompatible types in assignment (expression has type "function", variable has type "Callable[..., Any]")  [assignment]
Found 1 error in 1 file (checked 222 source files)
```

I've removed the type hint in `alibi_detect/base.py` since it doesn't appear to be used anyway:

```python
self.config: Dict[str, Any] = {
   ...
```

I can't recall why I added this type hint in the first place, but have checked and older versions of mypy (0.98x) still work without it...