### PR TITLE
Publish releases to PyPI via a GitHub Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
 
       - name: Build Python package
         run: |
-          make build_pypi
+          make build
 
 
   docs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,4 +46,5 @@ jobs:
       run: |
         make clean
         python -m pip install alibi-detect==${{ env.PACKAGE_VERS }}
-        python -c "from alibi_detect.cd import KSDrift"
+        python -c "import alibi_detect; print(alibi_detect)"
+        python -c "from alibi_detect.cd import *; print(MMDDrift)"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,8 @@ on:
   push:
     tags:
       - 'v*'
+  release:
+    types: [published]
 
 jobs:
   build-and-publish:
@@ -15,12 +17,6 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
-    # Setup version extractor (from tag)
-    - uses: nowsprinting/check-version-format-action@v3
-      id: version
-      with:
-        prefix: 'v'
-
     # Setup Python
     - uses: actions/checkout@master
     - name: Set up Python 3.9
@@ -29,27 +25,28 @@ jobs:
         python-version: 3.9
 
     # Build
-    - name: Install pypa/build
-      run: python -m pip install --user build==0.9.0
     - name: Build a binary wheel and a source tarball
-      run: python -m build --sdist --wheel --outdir dist/ .
+      run: make build
 
-    # Publish to Test PyPI unconditionally
+    # Publish to Test PyPI if this action was triggered by pushing a v* tag
     - name: Publish 📦 to Test PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-        repository_url: https://test.pypi.org/legacy/
+      if: github.event_name == 'push'  # check for `push` since action only triggered for tag pushes
+      run: |
+        python -m pip install .
+        echo "Dummy release of alibi-detect..."
+        python -c "from alibi_detect.version import __version__; print(__version__)" 
+      #     uses: pypa/gh-action-pypi-publish@release/v1
+      #     with:
+      #       password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+      #       repository_url: https://test.pypi.org/legacy/
 
-# TODO - Test below by:
-# 1) AVOID adding PyPI api token, to protect from inadvertant release if the conditional is broken
-# 2) Uncomment.
-# 3) Push a non-stable tag (e.g. v11.0.0-alpha1). Check below step is NOT triggered.
-# 4) Once happy, we can setup PyPI api token and it'll be ready to go.
-#    # Publish to real PyPI if the tag doesn't indicate a pre-release (i.e. not an alpha, beta or rc tag)
-#    (see https://github.com/nowsprinting/check-version-format-action#is_stable)
-#    - name: Publish 📦 to PyPI
-#      if: steps.version.outputs.prerelease == ''
-#      uses: pypa/gh-action-pypi-publish@release/v1
-#      with:
-#        password: ${{ secrets.PYPI_API_TOKEN }}        
+    # If this action was triggered by a GitHub release, publish the associated tag to PyPI
+    - name: Publish 📦 to PyPI
+      if: github.event_name == 'release'
+      run: |
+        python -m pip install .
+        echo "Dummy release of alibi-detect..."
+        python -c "from alibi_detect.version import __version__; print(__version__)" 
+        #      uses: pypa/gh-action-pypi-publish@release/v1
+        #      with:
+        #        password: ${{ secrets.PYPI_API_TOKEN }}        

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,9 +37,9 @@ jobs:
         password: ${{ secrets.PYPI_API_TOKEN }}
 
     # Wait for a while to give PyPI time to update (otherwise the pip install might fail)
-    - name: Sleep for 10 minutes
+    - name: Sleep for a minute
       shell: bash
-      run: sleep 10m
+      run: sleep 1m
 
     # Install from PyPI and test
     - name: Install 📦 from PyPI and test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,9 +37,9 @@ jobs:
         password: ${{ secrets.PYPI_API_TOKEN }}
 
     # Wait for a while to give PyPI time to update (otherwise the pip install might fail)
-    - name: Sleep for a minute
+    - name: Sleep for 3 minutes
       shell: bash
-      run: sleep 1m
+      run: sleep 3m
 
     # Install from PyPI and test
     - name: Install 📦 from PyPI and test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,55 @@
+# This github action builds Alibi Detect and publishes it to PyPI.
+# It is only run when a new tag is pushed to github.
+# See https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
+name: Publish 📦 to PyPI 
+
+# Only run when tags starting with "v" are pushed
+on: 
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build-and-publish:
+    name: Build and publish
+    runs-on: ubuntu-18.04
+
+    steps:
+    # Setup version extractor (from tag)
+    - uses: nowsprinting/check-version-format-action@v3
+      id: version
+      with:
+        prefix: 'v'
+
+    # Setup Python
+    - uses: actions/checkout@master
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.9
+
+    # Build
+    - name: Install pypa/build
+      run: python -m pip install --user build==0.9.0
+    - name: Build a binary wheel and a source tarball
+      run: python -m build --sdist --wheel --outdir dist/ .
+
+    # Publish to Test PyPI unconditionally
+    - name: Publish 📦 to Test PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/
+
+# TODO - Test below by:
+# 1) AVOID adding PyPI api token, to protect from inadvertant release if the conditional is broken
+# 2) Uncomment.
+# 3) Push a non-stable tag (e.g. v11.0.0-alpha1). Check below step is NOT triggered.
+# 4) Once happy, we can setup PyPI api token and it'll be ready to go.
+#    # Publish to real PyPI if the tag doesn't indicate a pre-release (i.e. not an alpha, beta or rc tag)
+#    (see https://github.com/nowsprinting/check-version-format-action#is_stable)
+#    - name: Publish 📦 to PyPI
+#      if: steps.version.outputs.prerelease == ''
+#      uses: pypa/gh-action-pypi-publish@release/v1
+#      with:
+#        password: ${{ secrets.PYPI_API_TOKEN }}        

--- a/.github/workflows/publish_test.yml
+++ b/.github/workflows/publish_test.yml
@@ -38,9 +38,9 @@ jobs:
       run: echo "PACKAGE_VERS=$(python setup.py --version)" >> $GITHUB_ENV
 
     # Wait for a while to give PyPI time to update (otherwise the pip install might fail)
-    - name: Sleep for 10 minutes
+    - name: Sleep for a minute
       shell: bash
-      run: sleep 10m
+      run: sleep 1m
 
     # Install from Test PyPI and test
     - name: Install 📦 from PyPI and test

--- a/.github/workflows/publish_test.yml
+++ b/.github/workflows/publish_test.yml
@@ -47,4 +47,5 @@ jobs:
       run: |
         make clean
         python -m pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple alibi-detect==${{ env.PACKAGE_VERS }}
-        python -c "from alibi_detect.cd import KSDrift"
+        python -c "import alibi_detect; print(alibi_detect)"
+        python -c "from alibi_detect.cd import *; print(MMDDrift)"

--- a/.github/workflows/publish_test.yml
+++ b/.github/workflows/publish_test.yml
@@ -48,4 +48,4 @@ jobs:
         make clean
         python -m pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple alibi-detect==${{ env.PACKAGE_VERS }}
         python -c "import alibi_detect; print(alibi_detect)"
-        python -c "from alibi_detect.cd import *; print(MMDDrift2)"
+        python -c "from alibi_detect.cd import *; print(MMDDrift)"

--- a/.github/workflows/publish_test.yml
+++ b/.github/workflows/publish_test.yml
@@ -48,4 +48,4 @@ jobs:
         make clean
         python -m pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple alibi-detect==${{ env.PACKAGE_VERS }}
         python -c "import alibi_detect; print(alibi_detect)"
-        python -c "from alibi_detect.cd import *; print(MMDDrift)"
+        python -c "from alibi_detect.cd import *; print(MMDDrift2)"

--- a/.github/workflows/publish_test.yml
+++ b/.github/workflows/publish_test.yml
@@ -38,9 +38,9 @@ jobs:
       run: echo "PACKAGE_VERS=$(python setup.py --version)" >> $GITHUB_ENV
 
     # Wait for a while to give PyPI time to update (otherwise the pip install might fail)
-    - name: Sleep for a minute
+    - name: Sleep for 3 minutes
       shell: bash
-      run: sleep 1m
+      run: sleep 3m
 
     # Install from Test PyPI and test
     - name: Install 📦 from PyPI and test

--- a/.github/workflows/publish_test.yml
+++ b/.github/workflows/publish_test.yml
@@ -1,12 +1,12 @@
-# This github action builds Alibi Detect and publishes it to PyPI.
-# It is only run when a new "release" is published via GitHub here:
-# https://github.com/SeldonIO/alibi-detect/releases
-name: Publish release to PyPI
+# This github action builds Alibi Detect and publishes it to Test PyPI.
+# It is only run when a new tag is pushed to github.
+name: Publish release to Test PyPI
 
 # Only run when tags starting with "v" are pushed
 on: 
-  release:
-    types: [published]
+  push:
+    tags:
+      - 'v*'
 
 jobs:
   build-and-publish:
@@ -25,25 +25,26 @@ jobs:
     - name: Build a binary wheel and a source tarball
       run: make build
 
+    # Publish to Test PyPI
+    - name: Publish 📦 to Test PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/
+
     # Get the PEP440 compliant version number (so we can check version is installable)
     - name: Get 📦 version number
       id: get_version
       run: echo "PACKAGE_VERS=$(python setup.py --version)" >> $GITHUB_ENV
-
-    # Publish the associated tag to PyPI
-    - name: Publish 📦 to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        password: ${{ secrets.PYPI_API_TOKEN }}
 
     # Wait for a while to give PyPI time to update (otherwise the pip install might fail)
     - name: Sleep for 10 minutes
       shell: bash
       run: sleep 10m
 
-    # Install from PyPI and test
+    # Install from Test PyPI and test
     - name: Install 📦 from PyPI and test
       run: |
         make clean
-        python -m pip install alibi-detect==${{ env.PACKAGE_VERS }}
+        python -m pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple alibi-detect==${{ env.PACKAGE_VERS }}
         python -c "from alibi_detect.cd import KSDrift"

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,14 @@
 install: ## Install package in editable mode with all the dependencies
 	pip install -e .
 
+.PHONY: clean
+clean:	# Clean up install
+	pip uninstall -y alibi-detect
+	rm -r alibi_detect.egg-info/ dist/ build/
+
 .PHONY: test
 test: ## Run all tests
-	python setup.py test
+	pytest alibi_detect
 
 .PHONY: lint
 lint: ## Check linting according to the flake8 configuration in setup.cfg
@@ -13,6 +18,12 @@ lint: ## Check linting according to the flake8 configuration in setup.cfg
 .PHONY: mypy
 mypy: ## Run typeckecking according to mypy configuration in setup.cfg
 	mypy .
+
+.PHONY: build
+build: ## Build the Python package (for debugging, building for release is done via a GitHub Action)
+	# (virtualenv installed due to Debian issue https://github.com/pypa/build/issues/224)
+	pip install --upgrade pip build virtualenv
+	python -m build --sdist --wheel
 
 .PHONY: build_docs
 build_docs:
@@ -31,18 +42,6 @@ build_latex: ## Build the documentation into a pdf
 clean_docs: ## Clean the documentation build
 	$(MAKE) -C doc clean
 	rm -r doc/source/api
-
-.PHONY: build_pypi
-build_pypi: ## Build the Python package
-	python setup.py sdist bdist_wheel
-
-.PHONY: push_pypi_test
-push_pypi_test: ## Upload the Python package to the test PyPI registry
-	twine upload --repository-url https://test.pypi.org/legacy/ dist/*
-
-.PHONY: push_pypi
-push_pypi: ## Upload the Python package to the PyPI registry
-	twine upload dist/*
 
 .PHONY: help
 help: ## Print out help message on using these commands

--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,11 @@ mypy: ## Run typeckecking according to mypy configuration in setup.cfg
 
 .PHONY: build
 build: ## Build the Python package (for debugging, building for release is done via a GitHub Action)
-	# (virtualenv installed due to Debian issue https://github.com/pypa/build/issues/224)
-	pip install --upgrade pip build virtualenv
-	python -m build --sdist --wheel
+	# Below commands are a duplicate of those in the publish.yml "Build" step
+	# (virtualenv added due to Debian issue https://github.com/pypa/build/issues/224)
+	python -m pip install --upgrade pip virtualenv
+	python -m pip install build~=0.9
+	python -m build --sdist --wheel --outdir dist/ .
 
 .PHONY: build_docs
 build_docs:

--- a/alibi_detect/version.py
+++ b/alibi_detect/version.py
@@ -3,4 +3,4 @@
 # 2) we can import it in setup.py for the same reason
 # 3) we can import it into your module module
 
-__version__ = "0.10.5-alpha5"
+__version__ = "0.10.5-alpha6"

--- a/alibi_detect/version.py
+++ b/alibi_detect/version.py
@@ -3,4 +3,4 @@
 # 2) we can import it in setup.py for the same reason
 # 3) we can import it into your module module
 
-__version__ = "0.10.5-alpha6"
+__version__ = "0.10.5-alpha7"

--- a/alibi_detect/version.py
+++ b/alibi_detect/version.py
@@ -3,4 +3,4 @@
 # 2) we can import it in setup.py for the same reason
 # 3) we can import it into your module module
 
-__version__ = "0.10.5-alpha7"
+__version__ = "0.10.5-alpha8"

--- a/alibi_detect/version.py
+++ b/alibi_detect/version.py
@@ -3,4 +3,4 @@
 # 2) we can import it in setup.py for the same reason
 # 3) we can import it into your module module
 
-__version__ = "0.11.0dev"
+__version__ = "0.10.5-alpha5"

--- a/alibi_detect/version.py
+++ b/alibi_detect/version.py
@@ -3,4 +3,4 @@
 # 2) we can import it in setup.py for the same reason
 # 3) we can import it into your module module
 
-__version__ = "0.11.0dev"
+__version__ = "0.10.5alpha2"

--- a/alibi_detect/version.py
+++ b/alibi_detect/version.py
@@ -3,4 +3,4 @@
 # 2) we can import it in setup.py for the same reason
 # 3) we can import it into your module module
 
-__version__ = "0.10.5-alpha8"
+__version__ = "0.11.0dev"

--- a/alibi_detect/version.py
+++ b/alibi_detect/version.py
@@ -3,4 +3,4 @@
 # 2) we can import it in setup.py for the same reason
 # 3) we can import it into your module module
 
-__version__ = "0.10.5alpha2"
+__version__ = "0.11.0dev"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-	"setuptools~=62.0.0",
-	"wheel~=0.37.0",
+	"setuptools~=65.5",
+	"wheel~=0.38",
 ]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = [
+	"setuptools~=62.0.0",
+	"wheel~=0.37.0",
+]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This PR implements a GitHub action workflow to publish releases. It is a more simple version of #495, with a `pyproject.toml` added to specify the `build-system` only (instead of replacing `setup.py`).

This removes the `make build_pypi` and `make push_pypi` steps (steps 7, 8. 10 in our [wiki](https://github.com/SeldonIO/alibi-detect/wiki/Release-process)) from the release process. This simplifies the release process a little, but the real benefit is that the process is properly isolated (and repeatable). It prevents differences in a dev's system from affecting the release process. For example, we have had instances before where a release has been broken due to a dev following the usual release process but in a conda env instead of a `virtualenv` (`setuptools` in conda for some reason includes different files in the `sdist`).

## Proposed release workflow
The expected release workflow is as follows:

1. Perform the usual git ops to get a `release/` branch i.e. form a `release/` branch from a previous tag and cherry-pick fixes, or branch off `master` etc. 
2. Make the usual changes to hard-coded version numbers (in `version.py`, `README.md` etc).
3. Make the final release commit and push it: `git commit -am "v0.x.x"; git push upstream master`
4. Tag the release commit and push it: `git tag v0.x.x; git push upstream v0.x.x`

Upon pushing the tag in step 4, the GitHub Action will automatically build the release and publish it to PyPI.

## Additional validation stage

An additional validation stage can be incorporated between steps 2 and 3:

 - Make a pre-release commit and push it: `git commit -am "v0.x.x-rc1"; git push upstream master`

The `rc` (or `alpha` or `beta`) in the tag means the GitHub Action will instead publish to Test PyPI. We can then install it with `pip install -i https://test.pypi.org/simple/ alibi-detect==0.x.xrc1` and check it before pushing the final release tag.

## Differences to #495

This PR is a watered-down version of #495, in case we'd rather think about this without committing to removing `setup.py`. #495 contains the following additional "improvements":

1. `setuptools_scm` is implemented. This sets `alibi_detect`'s version number from the latest git tag, meaning we don't have to hardcode the version in `alibi_detect/version.py` (annoyingly we still have to manually update the `README.md` and `CITATION.cff`).
2. `setup.py` is fully replaced by `pyproject.toml`. See #495 for a full discussion on this. In short, this is the future! 

## TODO's

- [ ] Finish new release process instructions on [wiki](https://github.com/SeldonIO/alibi-detect/wiki/Release-Process-(DRAFT)).
- [ ] Update GitHub Actions to pull in PyPI secrets for user that triggered action (if they exist).