### PR TITLE
Fix notebook tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,9 @@ jobs:
           if [ "$RUNNER_OS" == "macOS" ]; then  # Avoid numba/OpenMP segfault in CVMDrift (https://github.com/SeldonIO/alibi-detect/issues/648)
             export NUMBA_THREADING_LAYER="workqueue"
           fi
-          pytest alibi_detect
+          pytest --randomly-seed=0 alibi_detect
+          # Note: The pytest-randomly seed is fixed at 0 for now. Once the legacy np.random.seed(0)'s 
+          # are removed from tests, this can be removed, allowing all tests to use random seeds.
 
       - name: Upload coverage to Codecov
         if: ${{ success() }}

--- a/.github/workflows/test_all_notebooks.yml
+++ b/.github/workflows/test_all_notebooks.yml
@@ -45,4 +45,4 @@ jobs:
 
       - name: Run notebooks
         run: |
-          pytest --suppress-no-test-exit-code --no-cov -rA --durations=0 -vv testing/test_notebooks.py
+          pytest --suppress-no-test-exit-code --no-cov -rA --durations=0 -vv -p no:randomly testing/test_notebooks.py

--- a/.github/workflows/test_changed_notebooks.yml
+++ b/.github/workflows/test_changed_notebooks.yml
@@ -65,4 +65,4 @@ jobs:
         # adding the `or` quantifier between the names and concatenating with the test name `test_notebook_execution`.
         run: |
           tests="test_notebook_execution[$(echo ${FILES} | sed 's|doc/source/examples/||g' | sed 's| | or |g')]" &&
-          pytest --suppress-no-test-exit-code --no-cov -rA --durations=0 -vv testing/test_notebooks.py -k "$tests"
+          pytest --suppress-no-test-exit-code --no-cov -rA --durations=0 -vv -p no:randomly testing/test_notebooks.py -k "$tests"

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,13 +11,8 @@ addopts =
     --tb native
     -W ignore
     --cov=alibi_detect
-    --randomly-dont-reorganize
-    --randomly-seed=0
     #-n auto
     #--forked
-# randomly-dont-reorganize prevents pytest-randomly from reordering tests
-# The pytest-randomly seed is fixed at 0 for now. Once the legacy np.random.seed(0)'s 
-# are removed from tests, this can be removed, allowing all tests to use random seeds.
 
 [flake8]
 max-line-length = 120


### PR DESCRIPTION
`pytest-randomly` is disabled in the notebook CI in order to resolve #664 (see https://github.com/pytest-dev/pytest-randomly/issues/495). This isn't an ideal long-term solution, we might want to think about replacing `pytest-randomly` if https://github.com/pytest-dev/pytest-randomly/issues/495 is not going to be fixed.
