### PR TITLE
`fbprophet -> prophet` in doc/source/conf.py

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -102,7 +102,7 @@ autodoc_mock_imports = [
     "spacy",
     "tensorflow_probability",
     "scipy",
-    "fbprophet",
+    "prophet",
     "torch",
     "transformers",
     "tqdm",


### PR DESCRIPTION
Change `fbprophet` to `prophet` in `doc/source/conf.py`. Following https://github.com/SeldonIO/alibi-detect/pull/627.

Fixes the following warning when building docs (without `prophet` installed):

```
WARNING: autodoc: failed to import module 'prophet' from module 'alibi_detect.od'; the following exception was raised:
No module named 'prophet'
WARNING: Failed guarded type import with ModuleNotFoundError("No module named 'prophet'")
WARNING: Cannot resolve forward reference in type annotations of "alibi_detect.utils.fetching.fetch_detector": name 'OutlierProphet' is not defined
WARNING: Cannot resolve forward reference in type annotations of "alibi_detect.utils.fetching.fetching.fetch_detector": name 'OutlierProphet' is not defined
```