### PR TITLE
Add joblib to mocked libraries for docs

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -107,6 +107,7 @@ autodoc_mock_imports = [
     "transformers",
     "tqdm",
     "dill",
+    "joblib",
     "numba",
     "pydantic",
     "toml",


### PR DESCRIPTION
This PR adds `joblib` to the list of mocked libraries to prevent errors such as the following when building the docs:

```
WARNING: autodoc: failed to import module 'fetching' from module 'alibi_detect.utils'; the following exception was raised:
No module named 'joblib'
```