### PR TITLE
Fix `sphinx-autodoc-typehints` to <1.21

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,7 +1,7 @@
 # dependencies for building docs, separate from dev.txt as this is also used for builds on readthedocs.org
 # core dependencies
 sphinx>=4.2.0, <6.0.0
-sphinx-autodoc-typehints>=1.12.0, <1.19.3  # limited due to https://github.com/tox-dev/sphinx-autodoc-typehints/issues/259 and 260 
+sphinx-autodoc-typehints>=1.12.0, <1.21  # limited due to https://github.com/tox-dev/sphinx-autodoc-typehints/issues/260
 sphinx-rtd-theme>=1.0.0, <2.0.0
 sphinxcontrib-apidoc>=0.3.0, <0.4.0
 sphinxcontrib-bibtex>=2.1.0, <3.0.0


### PR DESCRIPTION
Fix `sphinx-autodoc-typehints` to `<1.21` since they will likely introduce `Sphinx>=6` in a `1.21` patch, which will break our CI (we're currently limited to `Sphinx<6.0` for now due to `sphinx-design` etc). See https://github.com/tox-dev/sphinx-autodoc-typehints/issues/260.

`alibi` equivalent: https://github.com/SeldonIO/alibi/pull/862