### PR TITLE
Replace Python 2 type comments with type annotations

### DIFF
--- a/alibi_detect/base.py
+++ b/alibi_detect/base.py
@@ -7,13 +7,13 @@ from typing_extensions import Protocol, runtime_checkable
 from alibi_detect.version import __version__
 
 
-DEFAULT_META = {
+DEFAULT_META: Dict = {
     "name": None,
     "online": None,  # true or false
     "data_type": None,  # tabular, image or time-series
     "version": None,
     "detector_type": None  # drift, outlier or adversarial
-}  # type: Dict
+}
 
 
 def outlier_prediction_dict():

--- a/alibi_detect/cd/sklearn/classifier.py
+++ b/alibi_detect/cd/sklearn/classifier.py
@@ -118,7 +118,7 @@ class ClassifierDriftSklearn(BaseClassifierDrift):
         self.use_calibration = use_calibration
         self.calibration_kwargs = dict() if calibration_kwargs is None else calibration_kwargs
         self.use_oob = use_oob
-        self.model = self._clone_model()  # type: ClassifierMixin
+        self.model: ClassifierMixin = self._clone_model()
 
     def _has_predict_proba(self, model) -> bool:
         try:

--- a/alibi_detect/od/mahalanobis.py
+++ b/alibi_detect/od/mahalanobis.py
@@ -1,7 +1,7 @@
 import logging
 import numpy as np
 from scipy.linalg import eigh
-from typing import Dict, Union
+from typing import Dict, Optional
 from alibi_detect.utils.discretizer import Discretizer
 from alibi_detect.utils.distance import abdm, mvdm, multidim_scaling
 from alibi_detect.utils.mapping import ohe2ord, ord2num
@@ -66,7 +66,7 @@ class Mahalanobis(BaseDetector, FitMixin, ThresholdMixin):
         self.d_abs: Dict = {}
 
         # initial parameter values
-        self.clip: Union[None, list] = None
+        self.clip: Optional[list] = None
         self.mean = 0
         self.C = 0
         self.n = 0

--- a/alibi_detect/od/mahalanobis.py
+++ b/alibi_detect/od/mahalanobis.py
@@ -63,10 +63,10 @@ class Mahalanobis(BaseDetector, FitMixin, ThresholdMixin):
         # keys = categorical columns; values = numerical value for each of the categories
         self.cat_vars = cat_vars
         self.ohe = ohe
-        self.d_abs = {}  # type: Dict
+        self.d_abs: Dict = {}
 
         # initial parameter values
-        self.clip = None  # type: Union[None, list]
+        self.clip: Union[None, list] = None
         self.mean = 0
         self.C = 0
         self.n = 0

--- a/alibi_detect/saving/_pytorch/saving.py
+++ b/alibi_detect/saving/_pytorch/saving.py
@@ -34,8 +34,8 @@ def save_model_config(model: Callable,
     -------
     A tuple containing the model and embedding config dicts.
     """
-    cfg_model = None  # type: Optional[Dict[str, Any]]
-    cfg_embed = None  # type: Optional[Dict[str, Any]]
+    cfg_model: Optional[Dict[str, Any]] = None
+    cfg_embed: Optional[Dict[str, Any]] = None
     if isinstance(model, UAE):
         layers = list(model.encoder.children())
         if isinstance(layers[0], TransformerEmbedding):  # if UAE contains embedding and encoder
@@ -118,7 +118,7 @@ def save_embedding_config(embed: TransformerEmbedding,
         filepath.mkdir(parents=True, exist_ok=True)
 
     # Populate config dict
-    cfg_embed = {}  # type: Dict[str, Any]
+    cfg_embed: Dict[str, Any] = {}
     cfg_embed.update({'type': embed.emb_type})
     cfg_embed.update({'layers': embed.hs_emb.keywords['layers']})
     cfg_embed.update({'src': local_path})

--- a/alibi_detect/saving/_tensorflow/loading.py
+++ b/alibi_detect/saving/_tensorflow/loading.py
@@ -234,7 +234,7 @@ def load_detector_legacy(filepath: Union[str, os.PathLike], suffix: str, **kwarg
     state_dict = dill.load(open(filepath.joinpath(detector_name + suffix), 'rb'))
 
     # initialize detector
-    detector = None  # type: Optional[Detector]  # to avoid mypy errors
+    detector: Optional[Detector] = None  # to avoid mypy errors
     if detector_name == 'OutlierAE':
         ae = load_tf_ae(filepath)
         detector = init_od_ae(state_dict, ae)

--- a/alibi_detect/saving/_tensorflow/saving.py
+++ b/alibi_detect/saving/_tensorflow/saving.py
@@ -50,8 +50,8 @@ def save_model_config(model: Callable,
     -------
     A tuple containing the model and embedding config dicts.
     """
-    cfg_model = None  # type: Optional[Dict[str, Any]]
-    cfg_embed = None  # type: Optional[Dict[str, Any]]
+    cfg_model: Optional[Dict[str, Any]] = None
+    cfg_embed: Optional[Dict[str, Any]] = None
     if isinstance(model, UAE):
         if isinstance(model.encoder.layers[0], TransformerEmbedding):  # if UAE contains embedding and encoder
             if input_shape is None:
@@ -145,7 +145,7 @@ def save_embedding_config(embed: TransformerEmbedding,
         filepath.mkdir(parents=True, exist_ok=True)
 
     # Populate config dict
-    cfg_embed = {}  # type: Dict[str, Any]
+    cfg_embed: Dict[str, Any] = {}
     cfg_embed.update({'type': embed.emb_type})
     cfg_embed.update({'layers': embed.hs_emb.keywords['layers']})
     cfg_embed.update({'src': local_path})

--- a/alibi_detect/saving/schemas.py
+++ b/alibi_detect/saving/schemas.py
@@ -1263,7 +1263,7 @@ class RegressorUncertaintyDriftConfigResolved(DetectorConfig):
 
 
 # Unresolved schema dictionary (used in alibi_detect.utils.loading)
-DETECTOR_CONFIGS = {
+DETECTOR_CONFIGS: Dict[str, Type[DetectorConfig]] = {
     'KSDrift': KSDriftConfig,
     'ChiSquareDrift': ChiSquareDriftConfig,
     'TabularDrift': TabularDriftConfig,
@@ -1281,11 +1281,11 @@ DETECTOR_CONFIGS = {
     'FETDriftOnline': FETDriftOnlineConfig,
     'ClassifierUncertaintyDrift': ClassifierUncertaintyDriftConfig,
     'RegressorUncertaintyDrift': RegressorUncertaintyDriftConfig,
-}  # type: Dict[str, Type[DetectorConfig]]
+}
 
 
 # Resolved schema dictionary (used in alibi_detect.utils.loading)
-DETECTOR_CONFIGS_RESOLVED = {
+DETECTOR_CONFIGS_RESOLVED: Dict[str, Type[DetectorConfig]] = {
     'KSDrift': KSDriftConfigResolved,
     'ChiSquareDrift': ChiSquareDriftConfigResolved,
     'TabularDrift': TabularDriftConfigResolved,
@@ -1303,4 +1303,4 @@ DETECTOR_CONFIGS_RESOLVED = {
     'FETDriftOnline': FETDriftOnlineConfigResolved,
     'ClassifierUncertaintyDrift': ClassifierUncertaintyDriftConfigResolved,
     'RegressorUncertaintyDrift': RegressorUncertaintyDriftConfigResolved,
-}  # type: Dict[str, Type[DetectorConfig]]
+}

--- a/alibi_detect/utils/_types.py
+++ b/alibi_detect/utils/_types.py
@@ -13,10 +13,10 @@ else:
 
 
 # Optional dep dependent tuples of types
-supported_models_tf = ()  # type: tuple
-supported_models_torch = ()  # type: tuple
-supported_optimizers_tf = ()  # type: tuple
-supported_optimizers_torch = ()  # type: tuple
+supported_models_tf: tuple = ()
+supported_models_torch: tuple = ()
+supported_optimizers_tf: tuple = ()
+supported_optimizers_torch: tuple = ()
 if has_tensorflow:
     import tensorflow as tf
     supported_models_tf = (tf.keras.Model, )

--- a/alibi_detect/utils/discretizer.py
+++ b/alibi_detect/utils/discretizer.py
@@ -27,8 +27,8 @@ class Discretizer(object):
         bins = self.bins(data)
         bins = [np.unique(x) for x in bins]
 
-        self.names = {}  # type: Dict[int, list]
-        self.lambdas = {}  # type: Dict[int, Callable]
+        self.names: Dict[int, list] = {}
+        self.lambdas: Dict[int, Callable] = {}
         for feature, qts in zip(self.to_discretize, bins):
 
             # get nb of borders (nb of bins - 1) and the feature name

--- a/alibi_detect/utils/distance.py
+++ b/alibi_detect/utils/distance.py
@@ -157,8 +157,8 @@ def abdm(X: np.ndarray, cat_vars: dict, cat_vars_bin: dict = dict()) -> dict:
     # combine dict for categorical with binned features
     cat_vars_combined = {**cat_vars, **cat_vars_bin}
 
-    d_pair = {}  # type: Dict
-    X_cat_eq = {}  # type: Dict
+    d_pair: Dict = {}
+    X_cat_eq: Dict = {}
     for col, n_cat in cat_vars.items():
         X_cat_eq[col] = []
         for i in range(n_cat):  # for each category in categorical variable, store instances of each category

--- a/alibi_detect/utils/fetching/fetching.py
+++ b/alibi_detect/utils/fetching/fetching.py
@@ -506,7 +506,7 @@ def fetch_detector(filepath: Union[str, os.PathLike],
 
     # load detector
     name = meta['name']
-    kwargs = {}  # type: dict
+    kwargs: dict = {}
     if name == 'OutlierAE':
         fetch_ae(url, filepath)
     elif name == 'OutlierAEGMM':

--- a/alibi_detect/utils/mapping.py
+++ b/alibi_detect/utils/mapping.py
@@ -138,7 +138,7 @@ def ohe2ord(X_ohe: np.ndarray, cat_vars_ohe: dict) -> Tuple[np.ndarray, dict]:
     """
     n, cols = X_ohe.shape
     ohe_vars_keys = list(cat_vars_ohe.keys())
-    X_list = []  # type: List
+    X_list: List = []
     c = 0
     cat_vars_ord = {}
     while c < cols:

--- a/alibi_detect/utils/pytorch/distance.py
+++ b/alibi_detect/utils/pytorch/distance.py
@@ -73,14 +73,14 @@ def batch_compute_kernel_matrix(
     n_x, n_y = len(x), len(y)
     n_batch_x, n_batch_y = int(np.ceil(n_x / batch_size)), int(np.ceil(n_y / batch_size))
     with torch.no_grad():
-        k_is = []  # type: List[torch.Tensor]
+        k_is: List[torch.Tensor] = []
         for i in range(n_batch_x):
             istart, istop = i * batch_size, min((i + 1) * batch_size, n_x)
             x_batch = x[istart:istop]
             if preprocess_fn is not None:
                 x_batch = preprocess_fn(x_batch)
             x_batch = x_batch.to(device)  # type: ignore
-            k_ijs = []  # type: List[torch.Tensor]
+            k_ijs: List[torch.Tensor] = []
             for j in range(n_batch_y):
                 jstart, jstop = j * batch_size, min((j + 1) * batch_size, n_y)
                 y_batch = y[jstart:jstop]

--- a/alibi_detect/utils/pytorch/prediction.py
+++ b/alibi_detect/utils/pytorch/prediction.py
@@ -41,7 +41,7 @@ def predict_batch(x: Union[list, np.ndarray, torch.Tensor], model: Union[Callabl
     n_minibatch = int(np.ceil(n / batch_size))
     return_np = not isinstance(dtype, torch.dtype)
     return_list = False
-    preds = []  # type: Union[list, tuple]
+    preds: Union[list, tuple] = []
     with torch.no_grad():
         for i in range(n_minibatch):
             istart, istop = i * batch_size, min((i + 1) * batch_size, n)
@@ -66,8 +66,8 @@ def predict_batch(x: Union[list, np.ndarray, torch.Tensor], model: Union[Callabl
                 raise TypeError(f'Model output type {type(preds_tmp)} not supported. The model output '
                                 f'type needs to be one of list, tuple, np.ndarray or torch.Tensor.')
     concat = partial(np.concatenate, axis=0) if return_np else partial(torch.cat, dim=0)  # type: ignore[arg-type]
-    out = tuple(concat(p) for p in preds) if isinstance(preds, tuple) \
-        else concat(preds)  # type: Union[tuple, np.ndarray, torch.Tensor]
+    out: Union[tuple, np.ndarray, torch.Tensor] = tuple(concat(p) for p in preds) if isinstance(preds, tuple) \
+        else concat(preds)
     if return_list:
         out = list(out)  # type: ignore[assignment]
     return out  # TODO: update return type with list

--- a/alibi_detect/utils/tensorflow/prediction.py
+++ b/alibi_detect/utils/tensorflow/prediction.py
@@ -33,7 +33,7 @@ def predict_batch(x: Union[list, np.ndarray, tf.Tensor], model: Union[Callable, 
     n_minibatch = int(np.ceil(n / batch_size))
     return_np = not isinstance(dtype, tf.DType)
     return_list = False
-    preds = []  # type: Union[list, tuple]
+    preds: Union[list, tuple] = []
     for i in range(n_minibatch):
         istart, istop = i * batch_size, min((i + 1) * batch_size, n)
         x_batch = x[istart:istop]


### PR DESCRIPTION
This PR replaces Python 2 type comments with type annotations. This will allow CI to pass with `flake8 >= 6.0` (https://github.com/SeldonIO/alibi-detect/pull/682).

**Note**: Will need to do the same with `alibi`. The command `grep -r "# type:" alibi/* | grep -Eiv "ignore" can be used to find all typing comments whilst excluding `# type: ignore` comments.