### PR TITLE
Fix legacy loading of detectors with tf models (v0.10.5 patch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## v0.10.5
+## [v0.10.5](https://github.com/SeldonIO/alibi-detect/tree/v0.10.5) (2023-01-24)
+[Full Changelog](https://github.com/SeldonIO/alibi-detect/compare/v0.10.4...v0.10.5)
+
+### Fixed
+- Fixed a bug preventing backward compatibility when loading detectors (containing TensorFlow models) saved with `alibi-detect<0.10.0`
+([#729](https://github.com/SeldonIO/alibi-detect/pull/729)). This bug also meant that detectors (containing TensorFlow models) saved with 
+`save_detector(..., legacy=True)` in `alibi-detect>=0.10.0` did not properly obey the legacy file format. The `config.toml` file format used by 
+default in `alibi-detect>=0.10.0` is not affected. 
+
 ## v0.10.4
 ## [v0.10.4](https://github.com/SeldonIO/alibi-detect/tree/v0.10.4) (2022-10-21)
 [Full Changelog](https://github.com/SeldonIO/alibi-detect/compare/v0.10.3...v0.10.4)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,10 @@
 [Full Changelog](https://github.com/SeldonIO/alibi-detect/compare/v0.10.4...v0.10.5)
 
 ### Fixed
-- Fixed a bug preventing backward compatibility when loading detectors (containing TensorFlow models) saved with `alibi-detect<0.10.0`
+- Fixed a bug preventing backward compatibility when loading detectors (containing TensorFlow models) saved with `<v0.10.0`
 ([#729](https://github.com/SeldonIO/alibi-detect/pull/729)). This bug also meant that detectors (containing TensorFlow models) saved with 
-`save_detector(..., legacy=True)` in `alibi-detect>=0.10.0` did not properly obey the legacy file format. The `config.toml` file format used by 
-default in `alibi-detect>=0.10.0` is not affected. 
+`save_detector(..., legacy=True)` in `>=v0.10.0` did not properly obey the legacy file format. The `config.toml` file format used by 
+default in `>=v0.10.0` is not affected. 
 
 ## v0.10.4
 ## [v0.10.4](https://github.com/SeldonIO/alibi-detect/tree/v0.10.4) (2022-10-21)

--- a/alibi_detect/saving/loading.py
+++ b/alibi_detect/saving/loading.py
@@ -263,7 +263,7 @@ def _load_model_config(cfg: dict,
                                 "a compatible model.")
 
     if backend == 'tensorflow':
-        model = load_model_tf(src, load_dir='.', custom_objects=custom_obj, layer=layer)
+        model = load_model_tf(src, custom_objects=custom_obj, layer=layer)
     else:
         raise NotImplementedError('Loading of non-tensorflow models not currently supported')
 

--- a/alibi_detect/saving/tensorflow/_loading.py
+++ b/alibi_detect/saving/tensorflow/_loading.py
@@ -277,6 +277,7 @@ def load_detector_legacy(filepath: Union[str, os.PathLike], suffix: str, **kwarg
         try:  # legacy load_model behaviour was to return None if not found. Now it raises error, hence need try-except.
             model = load_model(model_dir, filename='encoder')
         except FileNotFoundError:
+            logger.warning('No model found in {}, setting `model` to `None`.'.format(model_dir))
             model = None
         if detector_name == 'KSDrift':
             load_fn = init_cd_ksdrift  # type: ignore[assignment]

--- a/alibi_detect/saving/tensorflow/_loading.py
+++ b/alibi_detect/saving/tensorflow/_loading.py
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 
 
 def load_model(filepath: Union[str, os.PathLike],
-               load_dir: str = 'model',
+               filename: str = 'model',
                custom_objects: dict = None,
                layer: Optional[int] = None,
                ) -> tf.keras.Model:
@@ -45,8 +45,8 @@ def load_model(filepath: Union[str, os.PathLike],
     ----------
     filepath
         Saved model directory.
-    load_dir
-        Name of saved model folder within the filepath directory.
+    filename
+        Name of saved model within the filepath directory.
     custom_objects
         Optional custom objects when loading the TensorFlow model.
     layer
@@ -58,11 +58,12 @@ def load_model(filepath: Union[str, os.PathLike],
     Loaded model.
     """
     # TODO - update this to accept tf format - later PR.
-    model_dir = Path(filepath).joinpath(load_dir)
+    model_dir = Path(filepath)
+    model_name = filename + '.h5'
     # Check if model exists
-    if 'model.h5' not in [f.name for f in model_dir.glob('[!.]*.h5')]:
-        raise FileNotFoundError(f'No .h5 file found in {model_dir}.')
-    model = tf.keras.models.load_model(model_dir.joinpath('model.h5'), custom_objects=custom_objects)
+    if model_name not in [f.name for f in model_dir.glob('[!.]*.h5')]:
+        raise FileNotFoundError(f'{model_name} not found in {model_dir.resolve()}.')
+    model = tf.keras.models.load_model(model_dir.joinpath(model_name), custom_objects=custom_objects)
     # Optionally extract hidden layer
     if isinstance(layer, int):
         model = HiddenOutput(model, layer=layer)
@@ -233,7 +234,8 @@ def load_detector_legacy(filepath: Union[str, os.PathLike], suffix: str, **kwarg
     state_dict = dill.load(open(filepath.joinpath(detector_name + suffix), 'rb'))
 
     # initialize detector
-    detector = None  # type: Optional[Detector]  # to avoid mypy errors
+    model_dir = filepath.joinpath('model')
+    detector: Optional[Detector] = None  # to avoid mypy errors
     if detector_name == 'OutlierAE':
         ae = load_tf_ae(filepath)
         detector = init_od_ae(state_dict, ae)
@@ -253,13 +255,13 @@ def load_detector_legacy(filepath: Union[str, os.PathLike], suffix: str, **kwarg
     elif detector_name == 'AdversarialAE':
         ae = load_tf_ae(filepath)
         custom_objects = kwargs['custom_objects'] if 'custom_objects' in k else None
-        model = load_model(filepath, custom_objects=custom_objects)
+        model = load_model(model_dir, custom_objects=custom_objects)
         model_hl = load_tf_hl(filepath, model, state_dict)
         detector = init_ad_ae(state_dict, ae, model, model_hl)
     elif detector_name == 'ModelDistillation':
-        md = load_model(filepath, load_dir='distilled_model')
+        md = load_model(model_dir, filename='distilled_model')
         custom_objects = kwargs['custom_objects'] if 'custom_objects' in k else None
-        model = load_model(filepath, custom_objects=custom_objects)
+        model = load_model(model_dir, custom_objects=custom_objects)
         detector = init_ad_md(state_dict, md, model)
     elif detector_name == 'OutlierProphet':
         detector = init_od_prophet(state_dict)  # type: ignore[assignment]
@@ -273,7 +275,7 @@ def load_detector_legacy(filepath: Union[str, os.PathLike], suffix: str, **kwarg
         if state_dict['other']['load_text_embedding']:
             emb, tokenizer = load_text_embed(filepath)
         try:  # legacy load_model behaviour was to return None if not found. Now it raises error, hence need try-except.
-            model = load_model(filepath, load_dir='encoder')
+            model = load_model(model_dir, filename='encoder')
         except FileNotFoundError:
             model = None
         if detector_name == 'KSDrift':
@@ -286,7 +288,7 @@ def load_detector_legacy(filepath: Union[str, os.PathLike], suffix: str, **kwarg
             load_fn = init_cd_tabulardrift  # type: ignore[assignment]
         elif detector_name == 'ClassifierDriftTF':
             # Don't need try-except here since model is not optional for ClassifierDrift
-            clf_drift = load_model(filepath, load_dir='clf_drift')
+            clf_drift = load_model(model_dir, filename='clf_drift')
             load_fn = partial(init_cd_classifierdrift, clf_drift)  # type: ignore[assignment]
         else:
             raise NotImplementedError

--- a/alibi_detect/saving/tensorflow/_saving.py
+++ b/alibi_detect/saving/tensorflow/_saving.py
@@ -77,14 +77,14 @@ def save_model_config(model: Callable,
 
     if model is not None:
         filepath = base_path.joinpath(local_path)
-        save_model(model, filepath=filepath, save_dir='model')
+        save_model(model, filepath=filepath.joinpath('model'))
         cfg_model = {'src': local_path.joinpath('model')}
     return cfg_model, cfg_embed
 
 
 def save_model(model: tf.keras.Model,
                filepath: Union[str, os.PathLike],
-               save_dir: Union[str, os.PathLike] = 'model',
+               filename: str = 'model',
                save_format: Literal['tf', 'h5'] = 'h5') -> None:  # TODO - change to tf, later PR
     """
     Save TensorFlow model.
@@ -95,20 +95,20 @@ def save_model(model: tf.keras.Model,
         The tf.keras.Model to save.
     filepath
         Save directory.
-    save_dir
-        Name of folder to save to within the filepath directory.
+    filename
+        Name of file to save to within the filepath directory.
     save_format
         The format to save to. 'tf' to save to the newer SavedModel format, 'h5' to save to the lighter-weight
         legacy hdf5 format.
     """
     # create folder to save model in
-    model_path = Path(filepath).joinpath(save_dir)
+    model_path = Path(filepath)
     if not model_path.is_dir():
         logger.warning('Directory {} does not exist and is now created.'.format(model_path))
         model_path.mkdir(parents=True, exist_ok=True)
 
     # save model
-    model_path = model_path.joinpath('model.h5') if save_format == 'h5' else model_path
+    model_path = model_path.joinpath(filename + '.h5') if save_format == 'h5' else model_path
 
     if isinstance(model, tf.keras.Model):
         model.save(model_path, save_format=save_format)
@@ -231,30 +231,31 @@ def save_detector_legacy(detector, filepath):
         dill.dump(state_dict, f)
 
     # save detector specific TensorFlow models
+    model_dir = filepath.joinpath('model')
     if isinstance(detector, OutlierAE):
         save_tf_ae(detector, filepath)
     elif isinstance(detector, OutlierVAE):
         save_tf_vae(detector, filepath)
     elif isinstance(detector, (ChiSquareDrift, ClassifierDrift, KSDrift, MMDDrift, TabularDrift)):
         if model is not None:
-            save_model(model, filepath, save_dir='encoder')
+            save_model(model, model_dir, filename='encoder')
         if embed is not None:
             save_embedding_legacy(embed, embed_args, filepath)
         if tokenizer is not None:
             tokenizer.save_pretrained(filepath.joinpath('model'))
         if detector_name == 'ClassifierDriftTF':
-            save_model(clf_drift, filepath, save_dir='clf_drift')
+            save_model(clf_drift, model_dir, filename='clf_drift')
     elif isinstance(detector, OutlierAEGMM):
         save_tf_aegmm(detector, filepath)
     elif isinstance(detector, OutlierVAEGMM):
         save_tf_vaegmm(detector, filepath)
     elif isinstance(detector, AdversarialAE):
         save_tf_ae(detector, filepath)
-        save_model(detector.model, filepath)
+        save_model(detector.model, model_dir)
         save_tf_hl(detector.model_hl, filepath)
     elif isinstance(detector, ModelDistillation):
-        save_model(detector.distilled_model, filepath, save_dir='distilled_model')
-        save_model(detector.model, filepath, save_dir='model')
+        save_model(detector.distilled_model, model_dir, filename='distilled_model')
+        save_model(detector.model, model_dir, filename='model')
     elif isinstance(detector, OutlierSeq2Seq):
         save_tf_s2s(detector, filepath)
     elif isinstance(detector, LLR):

--- a/alibi_detect/utils/tests/test_saving_legacy.py
+++ b/alibi_detect/utils/tests/test_saving_legacy.py
@@ -1,6 +1,6 @@
 """
 Tests for saving/loading of detectors with legacy .dill state_dict. As legacy save/load functionality becomes
-deprecated, these tests will be removed, and more tests will be added to test_savin.py.
+deprecated, these tests will be removed, and more tests will be added to test_saving.py.
 """
 from alibi_detect.utils.missing_optional_dependency import MissingDependency
 from functools import partial


### PR DESCRIPTION
This PR fixes a bug in the legacy load functionality (of `.pickle`/`.dill` files generated by old `alibi-detect` versions). The bug meant that the detectors stored in https://console.cloud.google.com/storage/browser/seldon-models/alibi-detect could not be successfully loaded, because models were expected to be loaded from `filepath/encoder/model.h5`, instead of `filepath/model/encoder.h5`. 

This was not picked up in the `test_saving_legacy.py` tests, because these operate by instantiating a detector, saving it, and then reloading it (hence the incorrect naming convention was adopted when saving). 

## Testing
CI runs:  https://github.com/ascillitoe/alibi-detect/actions/runs/3995538470

Backward compatibility has been tested by loading (and checking) the following test matrix of artefacts from https://console.cloud.google.com/storage/browser/seldon-models/alibi-detect (see https://github.com/SeldonIO/alibi-detect/pull/729#issuecomment-1401660837):

```python
TESTS = [
    # Outlier detectors
    {'detector_type': 'outlier', 'detector_name': 'IForest', 'dataset': ['kddcup']},
    {'detector_type': 'outlier', 'detector_name': 'LLR', 'dataset': ['fashion_mnist', 'genome']},
    {'detector_type': 'outlier', 'detector_name': 'Mahalanobis', 'dataset': ['kddcup']},
    {'detector_type': 'outlier', 'detector_name': 'OutlierAE', 'dataset': ['cifar10']},
    {'detector_type': 'outlier', 'detector_name': 'OutlierAEGMM', 'dataset': ['kddcup']},
    {'detector_type': 'outlier', 'detector_name': 'OutlierProphet', 'dataset': ['weather']},
    {'detector_type': 'outlier', 'detector_name': 'OutlierSeq2Seq', 'dataset': ['ecg']},
    {'detector_type': 'outlier', 'detector_name': 'OutlierVAE', 'dataset': ['adult', 'cifar10', 'kddcup']},
    {'detector_type': 'outlier', 'detector_name': 'OutlierVAEGMM', 'dataset': ['kddcup']},
    # Adversarial detectors
    {'detector_type': 'adversarial', 'detector_name': 'model_distillation', 'dataset': ['cifar10'], 'model': ['resnet32']},
    # Drift detectors (not supported by `fetch_detector`...)
    {'detector_type': 'drift', 'detector_name': 'ks', 'dataset': ['cifar10', 'imdb'], 'version': ['0.6.2']},
    {'detector_type': 'drift', 'detector_name': 'mmd', 'dataset': ['cifar10'], 'version': ['0.8.1']},
    {'detector_type': 'drift', 'detector_name': 'tabular', 'dataset': ['income'], 'version': ['0.7.0', '0.8.1']},
]
```

where `{'detector_type': 'outlier', 'detector_name': 'IForest', 'dataset': ['kddcup']}` corresponds to `seldon-models/alibi-detect/od/IForest/kddcup`, and `{'detector_type': 'drift', 'detector_name': 'ks', 'dataset': ['cifar10', 'imdb'], 'version': ['0.6.2']}` to `seldon-models/alibi-detect/cd/ks/imdb-0_6_2`.

### Results

All the above artifacts are loaded successfully except for `{'detector_type': 'outlier', 'detector_name': 'LLR', 'dataset': 'genome'}` which fails with:

```
AttributeError: Can't get attribute 'likelihood_fn' on <module '__main__`
```

This artifact is very old. It is saved as `.pickle` instead of `.dill`, and the `likelihood_fn` defined in `https://docs.seldon.io/projects/alibi-detect/en/stable/examples/od_llr_genome.html` is not found at load time.

**Note**: artifacts with version numbers `<v0.6` are not included in `TESTS` since they use `.pickle`, and objects they reference such as `preprocess_drift` have since been moved to different locations in `alibi_detect`.