### PR TITLE
Run CI on all branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ on:
     branches:
       - master
   pull_request:
+    # don't trigger for draft PRs
     types: [ opened, synchronize, reopened, ready_for_review ]
   # Trigger workflow once per week
   schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,6 @@ on:
     branches:
       - master
   pull_request:
-    branches:
-      - master
-      - 'feature/*'
     types: [ opened, synchronize, reopened, ready_for_review ]
   # Trigger workflow once per week
   schedule:


### PR DESCRIPTION
Run CI on all branches so that we can check CI is passing for non-master branches such as patch releases (e.g. https://github.com/SeldonIO/alibi-detect/pull/729).

This is already the setup in `alibi`.