### PR TITLE
Build docs on Python 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,29 +96,28 @@ jobs:
   docs:
     if: github.event.pull_request.draft == false
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     container:
-      image: readthedocs/build:7.0  # 7.0 to get Python 3.9
+      image: readthedocs/build:ubuntu-22.04-2022.03.15
       options: --user root
 
     steps:
       - uses: actions/checkout@v3
-      - name: Create a virtualenv to use for docs build
-        run: |
-          python3.9 -m virtualenv $HOME/docs
+      - name: Set up Python 3.x
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
       - name: Install dependencies
         run: |
-          . $HOME/docs/bin/activate
+          python -m pip install --upgrade pip
           python -m pip install -r requirements/docs.txt
           python -m pip freeze
       - name: Build documentation to html
         run: |
-          . $HOME/docs/bin/activate
           make build_docs
       - name: Build documentation to pdf via latex
         run: |
-          . $HOME/docs/bin/activate
           make build_latex
 
   licenses:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,9 +7,9 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
-    python: "3.9"
+    python: "3.10"
   apt_packages:
     - pandoc
 

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -7,11 +7,11 @@ sphinxcontrib-apidoc>=0.3.0, <0.4.0
 sphinxcontrib-bibtex>=2.1.0, <3.0.0
 myst-parser>=0.14, <0.19
 nbsphinx>=0.8.5, <0.9.0
-sphinx_design==0.3.0  # Pinning for now as sphinx_design is v.new and still in flux. 
+sphinx_design==0.3.0  # Pinning for now as sphinx_design is v.new and still in flux.
 ipykernel>=5.1.0, <7.0.0 # required for executing notebooks via nbsphinx
 ipython>=7.2.0, <9.0.0 # required for executing notebooks nbsphinx
 # pandoc
-# pandoc==1.16.02 # NB: as this is not a Python library, it should be installed manually on the system or via a package manager such as `conda`
+# pandoc==2.9.2.1 # NB: as this is not a Python library, it should be installed manually on the system or via a package manager such as `conda`
 # alibi_detect dependencies (these are installed on ReadTheDocs so are not mocked)
 numpy>=1.16.2, <2.0.0
 pandas>=0.23.3, <2.0.0


### PR DESCRIPTION
- The docs on RTD are now built with `ubuntu-22.04` and using Python 3.10
- Updated the RTD build image used on GA docs build