### PR TITLE
Bump tensorflow to 2.12

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ extras_require = {
     # https://github.com/SeldonIO/alibi-detect/issues/375 and 387
     "tensorflow": [
         "tensorflow_probability>=0.8.0, <0.19.0",
-        "tensorflow>=2.2.0, !=2.6.0, !=2.6.1, <2.12.0",  # https://github.com/SeldonIO/alibi-detect/issues/375 and 387
+        "tensorflow>=2.2.0, !=2.6.0, !=2.6.1, <2.13.0",  # https://github.com/SeldonIO/alibi-detect/issues/375 and 387
     ],
     "keops": [
         "pykeops>=2.0.0, <2.2.0",
@@ -28,7 +28,7 @@ extras_require = {
     "all": [
         "prophet>=1.1.0, <2.0.0",
         "tensorflow_probability>=0.8.0, <0.19.0",
-        "tensorflow>=2.2.0, !=2.6.0, !=2.6.1, <2.12.0",  # https://github.com/SeldonIO/alibi-detect/issues/375 and 387
+        "tensorflow>=2.2.0, !=2.6.0, !=2.6.1, <2.13.0",  # https://github.com/SeldonIO/alibi-detect/issues/375 and 387
         "pykeops>=2.0.0, <2.2.0",
         "torch>=1.7.0, <1.14.0"
     ],


### PR DESCRIPTION
2.12 release notes [here](https://github.com/tensorflow/tensorflow/releases/tag/v2.12.0).

Possibly important changes:

- [x] Python 3.11 added and 3.7 dropped. - _No action needed. We are tracking upgrade to Python 3.11 in https://github.com/SeldonIO/alibi-detect/issues/676, and 3.7 will be dropped when EOL_
- [x] Moved all saving-related utilities to a new namespace, keras.saving, for example: keras.saving.load_model, keras.saving.save_model, keras.saving.custom_object_scope, keras.saving.get_custom_objects, keras.saving.register_keras_serializable,keras.saving.get_registered_name and keras.saving.get_registered_object. The previous API locations (in keras.utils and keras.models) will be available indefinitely, but we recommend you update your code to point to the new API locations. - _We could change `tf.keras.models.load_model` used in `saving._tensorflow.loading` to `tf.keras.saving.load_model`, but would need logic to cope with older tf versions, and old api locations available indefinitely, so best to leave._
- [x] The new Keras model saving format (.keras) is available. You can start using it via model.save(f"{fname}.keras", save_format="keras_v3"). In the future it will become the default for all files with the .keras extension.... - _We could explore moving to `keras_v3` instead of `SavedModel`, but would not be compatible with older tf versions so probably best to leave..._