### PR TITLE
Migrate codecov to github actions v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,9 +84,12 @@ jobs:
           # are removed from tests, this can be removed, allowing all tests to use random seeds.
 
       - name: Upload coverage to Codecov
-        if: ${{ success() }}
-        run: |
-          codecov -F ${{ matrix.os }}-${{ matrix.python-version }}
+        uses: codecov/codecov-action@v3
+        with:
+          directory: .
+          env_vars: ${{matrix.os}}, ${{matrix.python-version}}
+          fail_ci_if_error: true
+          verbose: true
 
       - name: Build Python package
         run: |

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -22,5 +22,4 @@ pre-commit>=1.20.0, <3.0.0
 tox>=3.21.0, <5.0.0 # used to generate licence info via `make licenses`
 twine>3.2.0, <4.0.0  # 4.x causes deps clashes with testing/requirements.txt, as requires rich>=12.0.0 -> requires typing-extensions>=4.0.0 -> too high for spacy and thinc!
 packaging>=19.0, <24.0 # Used to check scipy version for CVMDrift test. Can be removed once python 3.6 support dropped (and scipy lower bound >=1.7.0).
-codecov>=2.0.15, <3.0.0
 xgboost>=1.3.2, <2.0.0 # Install for use in testing since we support serialization of xgboost models under the sklearn API


### PR DESCRIPTION
## What is this:

Code-cov uploads breaking due to the uploader being [removed from pypi](https://github.com/codecov/python-standard/issues/31). This PR migrates to the [v3 GitHub action](https://github.com/marketplace/actions/codecov#usage).