### PR TITLE
avoid failure of plot_feature_outlier_image

### DIFF
--- a/alibi_detect/utils/visualize.py
+++ b/alibi_detect/utils/visualize.py
@@ -77,7 +77,7 @@ def plot_feature_outlier_image(od_preds: Dict,
         instance_ids = list(range(len(od_preds['data']['is_outlier'])))
     n_instances = min(max_instances, len(instance_ids))
     instance_ids = instance_ids[:n_instances]
-    
+
     if outliers_only and n_instances == 0:
         return
 

--- a/alibi_detect/utils/visualize.py
+++ b/alibi_detect/utils/visualize.py
@@ -79,6 +79,7 @@ def plot_feature_outlier_image(od_preds: Dict,
     instance_ids = instance_ids[:n_instances]
 
     if outliers_only and n_instances == 0:
+        warnings.warn('No outliers found!', UserWarning, stacklevel=3)
         return
 
     n_cols = 2

--- a/alibi_detect/utils/visualize.py
+++ b/alibi_detect/utils/visualize.py
@@ -77,6 +77,10 @@ def plot_feature_outlier_image(od_preds: Dict,
         instance_ids = list(range(len(od_preds['data']['is_outlier'])))
     n_instances = min(max_instances, len(instance_ids))
     instance_ids = instance_ids[:n_instances]
+    
+    if outliers_only and n_instances == 0:
+        return
+
     n_cols = 2
 
     if n_channels == 3:

--- a/alibi_detect/utils/visualize.py
+++ b/alibi_detect/utils/visualize.py
@@ -3,6 +3,7 @@ import numpy as np
 import pandas as pd
 from sklearn.metrics import roc_curve, auc
 from typing import Dict, Union
+import warnings
 
 
 def plot_instance_score(preds: Dict,

--- a/alibi_detect/utils/visualize.py
+++ b/alibi_detect/utils/visualize.py
@@ -80,7 +80,7 @@ def plot_feature_outlier_image(od_preds: Dict,
     instance_ids = instance_ids[:n_instances]
 
     if outliers_only and n_instances == 0:
-        warnings.warn('No outliers found!', UserWarning, stacklevel=3)
+        warnings.warn('No outliers found!', UserWarning)
         return
 
     n_cols = 2


### PR DESCRIPTION
I call the function this way:
```py
plot_feature_outlier_image(preds,  # output of an prediction
                                   ds, # my set of images
                                   X_recon=recon, # reconstructed set of images
                                   max_instances=5,       # max nb of instances to display
                                   n_channels=3,          # number of channels of the images
                                   figsize=(20,10),
                                   outliers_only=True)    # only show outlier predictions. this function fails when no outlier is detected and parameter set to True
```
In case there is no outlieres detected and the parameter outliers_only is set to True, then the function fails, because it calls plt.subplots(nrows=0, ....). 0 rows throws the error.