### PR TITLE
Remove torch.no_grad from od methods

### DIFF
--- a/alibi_detect/od/pytorch/ensemble.py
+++ b/alibi_detect/od/pytorch/ensemble.py
@@ -27,7 +27,6 @@ class BaseTransformTorch(Module):
         """
         raise NotImplementedError()
 
-    @torch.no_grad()
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return self.transform(x)
 

--- a/alibi_detect/od/pytorch/knn.py
+++ b/alibi_detect/od/pytorch/knn.py
@@ -42,7 +42,6 @@ class KNNTorch(TorchOutlierDetector):
         self.ks = torch.tensor(k) if self.ensemble else torch.tensor([k], device=self.device)
         self.ensembler = ensembler
 
-    @torch.no_grad()
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Detect if `x` is an outlier.
 
@@ -67,7 +66,6 @@ class KNNTorch(TorchOutlierDetector):
         preds = scores > self.threshold
         return preds
 
-    @torch.no_grad()
     def score(self, x: torch.Tensor) -> torch.Tensor:
         """Computes the score of `x`
 

--- a/alibi_detect/od/pytorch/mahalanobis.py
+++ b/alibi_detect/od/pytorch/mahalanobis.py
@@ -26,7 +26,6 @@ class MahalanobisTorch(TorchOutlierDetector):
         super().__init__(device=device)
         self.min_eigenvalue = min_eigenvalue
 
-    @torch.no_grad()
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Detect if `x` is an outlier.
 
@@ -50,7 +49,6 @@ class MahalanobisTorch(TorchOutlierDetector):
         preds = scores > self.threshold
         return preds
 
-    @torch.no_grad()
     def score(self, x: torch.Tensor) -> torch.Tensor:
         """Computes the score of `x`
 


### PR DESCRIPTION
## What is this

Removes torch scripting bug that arises due to the `torch.no_grad` context that decorates some of the outlier detectors methods.