### PR TITLE
Set `fail_ci_if_error` to false on codecov github acton

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
         with:
           directory: .
           env_vars: ${{matrix.os}}, ${{matrix.python-version}}
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           verbose: true
 
       - name: Build Python package


### PR DESCRIPTION
### What is this

Sets `fail_ci_if_error=false` in the codecov github ci. Quick fix that prevents the ci from falling due to [this](https://community.codecov.com/t/upload-issues-unable-to-locate-build-via-github-actions-api/3954) issue. See also #768