### PR TITLE
Fix hyperlinks in online drift detector docs

### DIFF
--- a/doc/source/cd/methods/onlinefetdrift.ipynb
+++ b/doc/source/cd/methods/onlinefetdrift.ipynb
@@ -140,7 +140,7 @@
     "cd.load_state('checkpoint_t1')\n",
     "```\n",
     "\n",
-    "At any point, the state may be reset to `t=0` with the `reset_state` method. When saving the detector with `save_detector`, the state will be saved, unless `t=0` (see [here](../overview/saving.md#online-detectors))."
+    "At any point, the state may be reset to `t=0` with the `reset_state` method. When saving the detector with `save_detector`, the state will be saved, unless `t=0` (see [here](../../overview/saving.md#online-detectors))."
    ]
   },
   {

--- a/doc/source/cd/methods/onlinelsdddrift.ipynb
+++ b/doc/source/cd/methods/onlinelsdddrift.ipynb
@@ -188,7 +188,7 @@
     "cd.load_state('checkpoint_t1')\n",
     "```\n",
     "\n",
-    "At any point, the state may be reset to `t=0` with the `reset_state` method. When saving the detector with `save_detector`, the state will be saved, unless `t=0` (see [here](../overview/saving.md#online-detectors))."
+    "At any point, the state may be reset to `t=0` with the `reset_state` method. When saving the detector with `save_detector`, the state will be saved, unless `t=0` (see [here](../../overview/saving.md#online-detectors))."
    ]
   },
   {

--- a/doc/source/cd/methods/onlinemmddrift.ipynb
+++ b/doc/source/cd/methods/onlinemmddrift.ipynb
@@ -193,7 +193,7 @@
     "cd.load_state('checkpoint_t1')\n",
     "```\n",
     "\n",
-    "At any point, the state may be reset to `t=0` with the `reset_state` method. When saving the detector with `save_detector`, the state will be saved, unless `t=0` (see [here](../overview/saving.md#online-detectors))."
+    "At any point, the state may be reset to `t=0` with the `reset_state` method. When saving the detector with `save_detector`, the state will be saved, unless `t=0` (see [here](../../overview/saving.md#online-detectors))."
    ]
   },
   {


### PR DESCRIPTION
Fixes three hyperlinks in the online drift detector methods pages.