### PR TITLE
Add .git-blame-ignore-revs file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Contains a large number of formatting changes for docstring return statements
+cbbee6cbaf649b989beca3552cd4148236cf52ef


### PR DESCRIPTION
## What is this

Adds the squashed commit from #789 `.git-blame-ignore-revs` file to prevent the large number of formatting changes in this work from polluting the git blame view.