### PR TITLE
Run CI on Python 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
+        python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11']
         include: # Run macos and windows tests on only one python version
           - os: windows-latest
             python-version: '3.9'  # PyTorch doesn't yet have 3.10 support on Windows (https://pytorch.org/get-started/locally/#windows-python)

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "License :: OSI Approved :: Apache Software License",
         "Topic :: Scientific/Engineering",
     ],


### PR DESCRIPTION
Resolves #676.

Likely needs https://github.com/SeldonIO/alibi-detect/pull/758 to be resolved first.

TODO:
 - [x] CI passes (`torch 1.13.1`: https://github.com/SeldonIO/alibi-detect/actions/runs/5313198052/jobs/9618752479?pr=817)
 - [ ]  ~CI passes `torch 2.x`~ (not needed for this PR as `3.11` is supported by `1.13.1`
 - [x] Update `README.md` (no changes needed)
 - [x] Update docs (no changes needed)
 - [x] Update `setup.py`