### PR TITLE
Fixes for numpy >= 1.24

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,10 +4,10 @@ repos:
     hooks:
       - id: flake8
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.0.1
+    rev: v1.4.1
     hooks:
       - id: mypy
         additional_dependencies: [
-          types-requests~=2.28,
+          types-requests~=2.31,
           types-toml~=0.10
         ]

--- a/alibi_detect/cd/base_online.py
+++ b/alibi_detect/cd/base_online.py
@@ -342,8 +342,7 @@ class BaseUniDriftOnline(BaseDetector, StateMixin):
         # Check the type of x
         if isinstance(x, np.ndarray):
             pass
-        # TODO: np.int, np.float checks deprecated in numpy 1.20
-        elif isinstance(x, (int, float, np.int, np.float)):  # type: ignore[attr-defined]
+        elif isinstance(x, (int, float)):
             x = np.array([x])
         else:
             raise TypeError("Detectors expect data to be 2D np.ndarray's. If data is passed as another type, a "

--- a/alibi_detect/cd/sklearn/classifier.py
+++ b/alibi_detect/cd/sklearn/classifier.py
@@ -298,7 +298,7 @@ class ClassifierDriftSklearn(BaseClassifierDrift):
         probs_oob = self.model.oob_decision_function_[idx_oob]
         y_oob = y[idx_oob]
         if isinstance(x, np.ndarray):
-            x_oob = x[idx_oob]
+            x_oob: Union[list, np.ndarray] = x[idx_oob]
         elif isinstance(x, list):
             x_oob = [x[_] for _ in idx_oob]
         else:

--- a/alibi_detect/utils/perturbation.py
+++ b/alibi_detect/utils/perturbation.py
@@ -1,6 +1,6 @@
 import random
 from io import BytesIO
-from typing import List, Tuple
+from typing import List, Tuple, Union
 
 import cv2
 import numpy as np
@@ -80,7 +80,7 @@ def apply_mask(X: np.ndarray,
     for _ in range(x_start.shape[0]):
 
         if mask_type == 'zero':
-            update_val = 0
+            update_val: Union[float, np.ndarray] = 0.0
         else:
             update_val = noise[_]
 


### PR DESCRIPTION
Replaces `np.int`, `np.float` with `int`, `float`, since `np.int` deprecated in numpy 1.24. See [Using the aliases of builtin types like np.int is deprecated](https://numpy.org/devdocs/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated).

This has become urgent since the new [scikit-learn 1.3.0](https://github.com/scikit-learn/scikit-learn/releases/tag/1.3.0) means `numpy >= 1.24` is now an allowable dependency of ours (and is installed in our CI).

**Will require a patch release**