### PR TITLE
Remove `scale_identity_multiplier` to support `tensorflow-probability 0.20`

### DIFF
--- a/alibi_detect/models/tensorflow/losses.py
+++ b/alibi_detect/models/tensorflow/losses.py
@@ -14,7 +14,9 @@ def elbo(y_true: tf.Tensor,
          sim: Optional[float] = None
          ) -> tf.Tensor:
     """
-    Compute ELBO loss.
+    Compute ELBO loss. The covariance matrix can be specified by passing the full covariance matrix, the matrix
+    diagonal, or a scale identity multiplier. Only one of these should be specified. If none are specified, the
+    identity matrix is used.
 
     Parameters
     ----------
@@ -32,6 +34,19 @@ def elbo(y_true: tf.Tensor,
     Returns
     -------
     ELBO loss value.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from alibi_detect.models.tensorflow.losses import elbo
+    >>> y_true = np.array([[0, 1], [1, 0]])
+    >>> y_pred = np.array([[0.1, 0.9], [0.8, 0.2]])
+    >>> # Specifying scale identity multiplier
+    >>> elbo(y_true, y_pred, sim=1.0)
+    >>> # Specifying covariance matrix diagonal
+    >>> elbo(y_true, y_pred, cov_diag=tf.ones(2))
+    >>> # Specifying full covariance matrix
+    >>> elbo(y_true, y_pred, cov_full=tf.eye(2))
     """
     if len([x for x in [cov_full, cov_diag, sim] if x is not None]) > 1:
         raise ValueError('Only one of cov_full, cov_diag or sim should be specified.')

--- a/alibi_detect/models/tensorflow/losses.py
+++ b/alibi_detect/models/tensorflow/losses.py
@@ -35,12 +35,12 @@ def elbo(y_true: tf.Tensor,
     -------
     ELBO loss value.
 
-    Examples
-    --------
-    >>> import numpy as np
+    Example
+    -------
+    >>> import tensorflow as tf
     >>> from alibi_detect.models.tensorflow.losses import elbo
-    >>> y_true = np.array([[0, 1], [1, 0]])
-    >>> y_pred = np.array([[0.1, 0.9], [0.8, 0.2]])
+    >>> y_true = tf.constant([[0.0, 1.0], [1.0, 0.0]])
+    >>> y_pred = tf.constant([[0.1, 0.9], [0.8, 0.2]])
     >>> # Specifying scale identity multiplier
     >>> elbo(y_true, y_pred, sim=1.0)
     >>> # Specifying covariance matrix diagonal

--- a/alibi_detect/models/tensorflow/losses.py
+++ b/alibi_detect/models/tensorflow/losses.py
@@ -11,7 +11,7 @@ def elbo(y_true: tf.Tensor,
          y_pred: tf.Tensor,
          cov_full: Optional[tf.Tensor] = None,
          cov_diag: Optional[tf.Tensor] = None,
-         sim: Optional[float] = .05
+         sim: Optional[float] = None
          ) -> tf.Tensor:
     """
     Compute ELBO loss.
@@ -33,8 +33,10 @@ def elbo(y_true: tf.Tensor,
     -------
     ELBO loss value.
     """
-    y_pred_flat = Flatten()(y_pred)
+    if len([x for x in [cov_full, cov_diag, sim] if x is not None]) > 1:
+        raise ValueError('Only one of cov_full, cov_diag or sim should be specified.')
 
+    y_pred_flat = Flatten()(y_pred)
     if isinstance(cov_full, tf.Tensor):
         y_mn = tfp.distributions.MultivariateNormalFullCovariance(y_pred_flat,
                                                                   covariance_matrix=cov_full)

--- a/alibi_detect/models/tensorflow/tests/test_losses_tf.py
+++ b/alibi_detect/models/tensorflow/tests/test_losses_tf.py
@@ -13,6 +13,7 @@ cov_full = tf.eye(x.shape[1])
 
 def test_elbo():
     assert elbo(x, y, cov_full=cov_full) == elbo(x, y, cov_diag=cov_diag) == elbo(x, y, sim=sim)
+    assert elbo(x, y) == elbo(x, y, sim=1.)  # Passing no kwarg's should lead to an identity covariance matrix
     assert elbo(x, y, sim=.05).numpy() > 0
     assert elbo(x, x, sim=.05).numpy() < 0
 

--- a/alibi_detect/models/tensorflow/tests/test_losses_tf.py
+++ b/alibi_detect/models/tensorflow/tests/test_losses_tf.py
@@ -1,3 +1,4 @@
+import pytest
 import numpy as np
 import tensorflow as tf
 from alibi_detect.models.tensorflow.losses import elbo, loss_adv_ae, loss_aegmm, loss_vaegmm, loss_distillation
@@ -14,6 +15,13 @@ def test_elbo():
     assert elbo(x, y, cov_full=cov_full) == elbo(x, y, cov_diag=cov_diag) == elbo(x, y, sim=sim)
     assert elbo(x, y, sim=.05).numpy() > 0
     assert elbo(x, x, sim=.05).numpy() < 0
+
+
+def test_elbo_error():
+    with pytest.raises(ValueError):
+        elbo(x, y, cov_full=cov_full, cov_diag=cov_diag)
+        elbo(x, y, cov_full=cov_full, sim=sim)
+        elbo(x, y, cov_diag=cov_diag, sim=sim)
 
 
 z = np.random.rand(N, D).astype(np.float32)

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ extras_require = {
     ],
     # https://github.com/SeldonIO/alibi-detect/issues/375 and 387
     "tensorflow": [
-        "tensorflow_probability>=0.8.0, <0.20.0",
+        "tensorflow_probability>=0.8.0, <0.21.0",
         "tensorflow>=2.2.0, !=2.6.0, !=2.6.1, <2.13.0",  # https://github.com/SeldonIO/alibi-detect/issues/375 and 387
     ],
     "keops": [
@@ -27,7 +27,7 @@ extras_require = {
     ],
     "all": [
         "prophet>=1.1.0, <2.0.0",
-        "tensorflow_probability>=0.8.0, <0.20.0",
+        "tensorflow_probability>=0.8.0, <0.21.0",
         "tensorflow>=2.2.0, !=2.6.0, !=2.6.1, <2.13.0",  # https://github.com/SeldonIO/alibi-detect/issues/375 and 387
         "pykeops>=2.0.0, <2.2.0",
         "torch>=1.7.0, <1.14.0"


### PR DESCRIPTION
In `tensorflow-probability` v0.20 the  `scale_identity_multiplier` kwarg given to `MultivariateNormalDiag` is removed, meaning the covariance matrix must be specified via `scale_diag` (see https://github.com/tensorflow/probability/commit/ca8485023767fc021e277ca1a987449d90f21cea)

This PR modifies our `elbo` loss function, so that `scale_diag` is constructed from the `sim` kwarg, rather than passing it directly to `scale_identity_multiplier`. Currently, only one of `cov_full`, `cov_diag` or `sim` should be given to `elbo`.

**Breaking change**: This currently involves a breaking change since the default value of `sim` in `elbo` has been changed from `sim=0.05` to `sim=None`. A possible alternative would be to have `sim=0.05` as the default, and then set `sim=None` under-the-hood when either `cov_diag` or `cov_full` are given (i.e. `not None`).