### PR TITLE
Convert threshold to float type acorss the new outlier detectors

### DIFF
--- a/alibi_detect/od/pytorch/base.py
+++ b/alibi_detect/od/pytorch/base.py
@@ -25,9 +25,10 @@ class TorchOutlierDetectorOutput:
         for f in fields(self):
             value = getattr(self, f.name)
             if isinstance(value, torch.Tensor):
-                result[f.name] = value.cpu().detach().numpy()
-            else:
-                result[f.name] = value
+                value = value.cpu().detach().numpy()
+            if isinstance(value, np.ndarray) and value.ndim == 0:
+                value = value.item()
+            result[f.name] = value
         return result
 
 

--- a/alibi_detect/od/sklearn/base.py
+++ b/alibi_detect/od/sklearn/base.py
@@ -13,7 +13,7 @@ class SklearnOutlierDetectorOutput:
     """Output of the outlier detector."""
     threshold_inferred: bool
     instance_score: np.ndarray
-    threshold: Optional[np.ndarray]
+    threshold: Optional[float]
     is_outlier: Optional[np.ndarray]
     p_value: Optional[np.ndarray]
 

--- a/alibi_detect/od/sklearn/base.py
+++ b/alibi_detect/od/sklearn/base.py
@@ -13,7 +13,7 @@ class SklearnOutlierDetectorOutput:
     """Output of the outlier detector."""
     threshold_inferred: bool
     instance_score: np.ndarray
-    threshold: Optional[float]
+    threshold: Optional[np.ndarray]
     is_outlier: Optional[np.ndarray]
     p_value: Optional[np.ndarray]
 

--- a/alibi_detect/od/tests/test__gmm/test__gmm.py
+++ b/alibi_detect/od/tests/test__gmm/test__gmm.py
@@ -73,6 +73,7 @@ def test_fitted_gmm_predict(backend):
     assert y['instance_score'][1] < 2
     assert y['threshold_inferred']
     assert y['threshold'] is not None
+    assert isinstance(y['threshold'], float)
     assert y['p_value'].all()
     assert (y['is_outlier'] == [True, False]).all()
 

--- a/alibi_detect/od/tests/test__knn/test__knn.py
+++ b/alibi_detect/od/tests/test__knn/test__knn.py
@@ -107,6 +107,7 @@ def test_fitted_knn_predict():
     assert y['instance_score'][1] < 1
     assert y['threshold_inferred']
     assert y['threshold'] is not None
+    assert isinstance(y['threshold'], float)
     assert y['p_value'].all()
     assert (y['is_outlier'] == [True, False]).all()
 
@@ -166,6 +167,7 @@ def test_fitted_knn_ensemble_predict(aggregator, normalizer):
     y = y['data']
     assert y['threshold_inferred']
     assert y['threshold'] is not None
+    assert isinstance(y['threshold'], float)
     assert y['p_value'].all()
     assert (y['is_outlier'] == [True, False]).all()
 

--- a/alibi_detect/od/tests/test__lof/test__lof.py
+++ b/alibi_detect/od/tests/test__lof/test__lof.py
@@ -105,6 +105,7 @@ def test_fitted_lof_predict():
     assert y['instance_score'][0] > y['instance_score'][1]
     assert y['threshold_inferred']
     assert y['threshold'] is not None
+    assert isinstance(y['threshold'], float)
     assert y['p_value'].all()
     assert (y['is_outlier'] == [True, False]).all()
 
@@ -164,6 +165,7 @@ def test_fitted_lof_ensemble_predict(aggregator, normalizer):
     y = y['data']
     assert y['threshold_inferred']
     assert y['threshold'] is not None
+    assert isinstance(y['threshold'], float)
     assert y['p_value'].all()
     assert (y['is_outlier'] == [True, False]).all()
 

--- a/alibi_detect/od/tests/test__mahalanobis/test__mahalanobis.py
+++ b/alibi_detect/od/tests/test__mahalanobis/test__mahalanobis.py
@@ -76,6 +76,7 @@ def test_fitted_mahalanobis_predict():
     assert y['instance_score'][1] < 1
     assert y['threshold_inferred']
     assert y['threshold'] is not None
+    assert isinstance(y['threshold'], float)
     assert y['p_value'].all()
     assert (y['is_outlier'] == [True, False]).all()
 

--- a/alibi_detect/od/tests/test__pca/test__pca.py
+++ b/alibi_detect/od/tests/test__pca/test__pca.py
@@ -105,6 +105,7 @@ def test_fitted_PCA_predict(detector):
     assert y['instance_score'][0] > y['instance_score'][1]
     assert y['threshold_inferred']
     assert y['threshold'] is not None
+    assert isinstance(y['threshold'], float)
     assert y['p_value'].all()
     assert (y['is_outlier'] == [True, False]).all()
 

--- a/alibi_detect/od/tests/test__svm/test__svm.py
+++ b/alibi_detect/od/tests/test__svm/test__svm.py
@@ -149,6 +149,7 @@ def test_fitted_svm_predict(optimization):
     assert y['instance_score'][1] < -0.8
     assert y['threshold_inferred']
     assert y['threshold'] is not None
+    assert isinstance(y['threshold'], float)
     assert y['p_value'].all()
     assert (y['is_outlier'] == [True, False]).all()
 


### PR DESCRIPTION
## What is this

This PR fixes: #809. Specifically it ensures that the threshold value outputted by the outlier detectors on a predict call is of type float across both Sklearn and PyTorch backends.
