### PR TITLE
Rename interface methods for mapping between frontend and backend

### DIFF
--- a/alibi_detect/od/_gmm.py
+++ b/alibi_detect/od/_gmm.py
@@ -127,7 +127,7 @@ class GMM(BaseDetector, ThresholdMixin, FitMixin):
             Verbosity level used to fit the detector. Used for both ``'sklearn'`` and ``'pytorch'`` backends. Defaults to ``0``.
         """
         self.backend.fit(
-            self.backend._to_tensor(x_ref),
+            self.backend._to_backend_dtype(x_ref),
             **self.backend.format_fit_kwargs(locals())
         )
 
@@ -153,8 +153,8 @@ class GMM(BaseDetector, ThresholdMixin, FitMixin):
         NotFittedError
             If called before detector has been fit.
         """
-        score = self.backend.score(self.backend._to_tensor(x))
-        return self.backend._to_numpy(score)
+        score = self.backend.score(self.backend._to_backend_dtype(x))
+        return self.backend._to_frontend_dtype(score)
 
     @catch_error('NotFittedError')
     def infer_threshold(self, x: np.ndarray, fpr: float) -> None:
@@ -179,7 +179,7 @@ class GMM(BaseDetector, ThresholdMixin, FitMixin):
         NotFittedError
             If called before detector has been fit.
         """
-        self.backend.infer_threshold(self.backend._to_tensor(x), fpr)
+        self.backend.infer_threshold(self.backend._to_backend_dtype(x), fpr)
 
     @catch_error('NotFittedError')
     def predict(self, x: np.ndarray) -> Dict[str, Any]:
@@ -204,11 +204,11 @@ class GMM(BaseDetector, ThresholdMixin, FitMixin):
         NotFittedError
             If called before detector has been fit.
         """
-        outputs = self.backend.predict(self.backend._to_tensor(x))
+        outputs = self.backend.predict(self.backend._to_backend_dtype(x))
         output = outlier_prediction_dict()
         output['data'] = {
             **output['data'],
-            **self.backend._to_numpy(outputs)
+            **self.backend._to_frontend_dtype(outputs)
         }
         output['meta'] = {
             **output['meta'],

--- a/alibi_detect/od/_knn.py
+++ b/alibi_detect/od/_knn.py
@@ -119,7 +119,7 @@ class KNN(BaseDetector, FitMixin, ThresholdMixin):
         x_ref
             Reference data used to fit the detector.
         """
-        self.backend.fit(self.backend._to_tensor(x_ref))
+        self.backend.fit(self.backend._to_backend_dtype(x_ref))
 
     @catch_error('NotFittedError')
     @catch_error('ThresholdNotInferredError')
@@ -147,9 +147,9 @@ class KNN(BaseDetector, FitMixin, ThresholdMixin):
         ThresholdNotInferredError
             If k is a list and a threshold was not inferred.
         """
-        score = self.backend.score(self.backend._to_tensor(x))
+        score = self.backend.score(self.backend._to_backend_dtype(x))
         score = self.backend._ensembler(score)
-        return self.backend._to_numpy(score)
+        return self.backend._to_frontend_dtype(score)
 
     @catch_error('NotFittedError')
     def infer_threshold(self, x: np.ndarray, fpr: float) -> None:
@@ -174,7 +174,7 @@ class KNN(BaseDetector, FitMixin, ThresholdMixin):
         NotFittedError
             If called before detector has been fit.
         """
-        self.backend.infer_threshold(self.backend._to_tensor(x), fpr)
+        self.backend.infer_threshold(self.backend._to_backend_dtype(x), fpr)
 
     @catch_error('NotFittedError')
     @catch_error('ThresholdNotInferredError')
@@ -202,11 +202,11 @@ class KNN(BaseDetector, FitMixin, ThresholdMixin):
         ThresholdNotInferredError
             If k is a list and a threshold was not inferred.
         """
-        outputs = self.backend.predict(self.backend._to_tensor(x))
+        outputs = self.backend.predict(self.backend._to_backend_dtype(x))
         output = outlier_prediction_dict()
         output['data'] = {
             **output['data'],
-            **self.backend._to_numpy(outputs)
+            **self.backend._to_frontend_dtype(outputs)
         }
         output['meta'] = {
             **output['meta'],

--- a/alibi_detect/od/_lof.py
+++ b/alibi_detect/od/_lof.py
@@ -118,7 +118,7 @@ class LOF(BaseDetector, FitMixin, ThresholdMixin):
         x_ref
             Reference data used to fit the detector.
         """
-        self.backend.fit(self.backend._to_tensor(x_ref))
+        self.backend.fit(self.backend._to_backend_dtype(x_ref))
 
     @catch_error('NotFittedError')
     @catch_error('ThresholdNotInferredError')
@@ -146,9 +146,9 @@ class LOF(BaseDetector, FitMixin, ThresholdMixin):
         ThresholdNotInferredError
             If k is a list and a threshold was not inferred.
         """
-        score = self.backend.score(self.backend._to_tensor(x))
+        score = self.backend.score(self.backend._to_backend_dtype(x))
         score = self.backend._ensembler(score)
-        return self.backend._to_numpy(score)
+        return self.backend._to_frontend_dtype(score)
 
     @catch_error('NotFittedError')
     def infer_threshold(self, x: np.ndarray, fpr: float) -> None:
@@ -173,7 +173,7 @@ class LOF(BaseDetector, FitMixin, ThresholdMixin):
         NotFittedError
             If called before detector has been fit.
         """
-        self.backend.infer_threshold(self.backend._to_tensor(x), fpr)
+        self.backend.infer_threshold(self.backend._to_backend_dtype(x), fpr)
 
     @catch_error('NotFittedError')
     @catch_error('ThresholdNotInferredError')
@@ -201,11 +201,11 @@ class LOF(BaseDetector, FitMixin, ThresholdMixin):
         ThresholdNotInferredError
             If k is a list and a threshold was not inferred.
         """
-        outputs = self.backend.predict(self.backend._to_tensor(x))
+        outputs = self.backend.predict(self.backend._to_backend_dtype(x))
         output = outlier_prediction_dict()
         output['data'] = {
             **output['data'],
-            **self.backend._to_numpy(outputs)
+            **self.backend._to_frontend_dtype(outputs)
         }
         output['meta'] = {
             **output['meta'],

--- a/alibi_detect/od/_mahalanobis.py
+++ b/alibi_detect/od/_mahalanobis.py
@@ -86,7 +86,7 @@ class Mahalanobis(BaseDetector, FitMixin, ThresholdMixin):
         x_ref
             Reference data used to fit the detector.
         """
-        self.backend.fit(self.backend._to_tensor(x_ref))
+        self.backend.fit(self.backend._to_backend_dtype(x_ref))
 
     @catch_error('NotFittedError')
     def score(self, x: np.ndarray) -> np.ndarray:
@@ -110,8 +110,8 @@ class Mahalanobis(BaseDetector, FitMixin, ThresholdMixin):
         NotFittedError
             If called before detector has been fit.
         """
-        score = self.backend.score(self.backend._to_tensor(x))
-        return self.backend._to_numpy(score)
+        score = self.backend.score(self.backend._to_backend_dtype(x))
+        return self.backend._to_frontend_dtype(score)
 
     @catch_error('NotFittedError')
     def infer_threshold(self, x: np.ndarray, fpr: float) -> None:
@@ -136,7 +136,7 @@ class Mahalanobis(BaseDetector, FitMixin, ThresholdMixin):
         NotFittedError
             If called before detector has been fit.
         """
-        self.backend.infer_threshold(self.backend._to_tensor(x), fpr)
+        self.backend.infer_threshold(self.backend._to_backend_dtype(x), fpr)
 
     @catch_error('NotFittedError')
     def predict(self, x: np.ndarray) -> Dict[str, Any]:
@@ -161,11 +161,11 @@ class Mahalanobis(BaseDetector, FitMixin, ThresholdMixin):
         NotFittedError
             If called before detector has been fit.
         """
-        outputs = self.backend.predict(self.backend._to_tensor(x))
+        outputs = self.backend.predict(self.backend._to_backend_dtype(x))
         output = outlier_prediction_dict()
         output['data'] = {
             **output['data'],
-            **self.backend._to_numpy(outputs)
+            **self.backend._to_frontend_dtype(outputs)
         }
         output['meta'] = {
             **output['meta'],

--- a/alibi_detect/od/_pca.py
+++ b/alibi_detect/od/_pca.py
@@ -116,7 +116,7 @@ class PCA(BaseDetector, ThresholdMixin, FitMixin):
             features or if using kernel pca variant and `n_components` is greater than or equal
             to number of instances.
         """
-        self.backend.fit(self.backend._to_tensor(x_ref))
+        self.backend.fit(self.backend._to_backend_dtype(x_ref))
 
     @catch_error('NotFittedError')
     def score(self, x: np.ndarray) -> np.ndarray:
@@ -139,8 +139,8 @@ class PCA(BaseDetector, ThresholdMixin, FitMixin):
         NotFittedError
             If called before detector has been fit.
         """
-        score = self.backend.score(self.backend._to_tensor(x))
-        return self.backend._to_numpy(score)
+        score = self.backend.score(self.backend._to_backend_dtype(x))
+        return self.backend._to_frontend_dtype(score)
 
     @catch_error('NotFittedError')
     def infer_threshold(self, x: np.ndarray, fpr: float) -> None:
@@ -165,7 +165,7 @@ class PCA(BaseDetector, ThresholdMixin, FitMixin):
         NotFittedError
             If called before detector has been fit.
         """
-        self.backend.infer_threshold(self.backend._to_tensor(x), fpr)
+        self.backend.infer_threshold(self.backend._to_backend_dtype(x), fpr)
 
     @catch_error('NotFittedError')
     def predict(self, x: np.ndarray) -> Dict[str, Any]:
@@ -190,11 +190,11 @@ class PCA(BaseDetector, ThresholdMixin, FitMixin):
         NotFittedError
             If called before detector has been fit.
         """
-        outputs = self.backend.predict(self.backend._to_tensor(x))
+        outputs = self.backend.predict(self.backend._to_backend_dtype(x))
         output = outlier_prediction_dict()
         output['data'] = {
             **output['data'],
-            **self.backend._to_numpy(outputs)
+            **self.backend._to_frontend_dtype(outputs)
         }
         output['meta'] = {
             **output['meta'],

--- a/alibi_detect/od/_svm.py
+++ b/alibi_detect/od/_svm.py
@@ -144,7 +144,7 @@ class SVM(BaseDetector, ThresholdMixin, FitMixin):
             progress bar. Otherwise, if using `sgd` then we output the Sklearn `SGDOneClassSVM.fit()` logs.
         """
         self.backend.fit(
-            self.backend._to_tensor(x_ref),
+            self.backend._to_backend_dtype(x_ref),
             **self.backend.format_fit_kwargs(locals())
         )
 
@@ -169,8 +169,8 @@ class SVM(BaseDetector, ThresholdMixin, FitMixin):
         NotFittedError
             If called before detector has been fit.
         """
-        score = self.backend.score(self.backend._to_tensor(x))
-        return self.backend._to_numpy(score)
+        score = self.backend.score(self.backend._to_backend_dtype(x))
+        return self.backend._to_frontend_dtype(score)
 
     @catch_error('NotFittedError')
     def infer_threshold(self, x: np.ndarray, fpr: float) -> None:
@@ -195,7 +195,7 @@ class SVM(BaseDetector, ThresholdMixin, FitMixin):
         NotFittedError
             If called before detector has been fit.
         """
-        self.backend.infer_threshold(self.backend._to_tensor(x), fpr)
+        self.backend.infer_threshold(self.backend._to_backend_dtype(x), fpr)
 
     @catch_error('NotFittedError')
     def predict(self, x: np.ndarray) -> Dict[str, Any]:
@@ -220,11 +220,11 @@ class SVM(BaseDetector, ThresholdMixin, FitMixin):
         NotFittedError
             If called before detector has been fit.
         """
-        outputs = self.backend.predict(self.backend._to_tensor(x))
+        outputs = self.backend.predict(self.backend._to_backend_dtype(x))
         output = outlier_prediction_dict()
         output['data'] = {
             **output['data'],
-            **self.backend._to_numpy(outputs)
+            **self.backend._to_frontend_dtype(outputs)
         }
         output['meta'] = {
             **output['meta'],

--- a/alibi_detect/od/pytorch/svm.py
+++ b/alibi_detect/od/pytorch/svm.py
@@ -196,7 +196,7 @@ class SgdSVMTorch(SVMTorch):
         coef_ = self.svm.coef_ / (self.svm.coef_ ** 2).sum()
         x_nys = self.svm._validate_data(x_nys, accept_sparse="csr", reset=False)
         result = safe_sparse_dot(x_nys, coef_.T, dense_output=True).ravel()
-        return - self._to_tensor(result)
+        return - self._to_backend_dtype(result)
 
 
 class BgdSVMTorch(SVMTorch):

--- a/alibi_detect/od/sklearn/base.py
+++ b/alibi_detect/od/sklearn/base.py
@@ -81,10 +81,14 @@ class SklearnOutlierDetector(FitMixinSklearn, ABC):
             raise ThresholdNotInferredError(self.__class__.__name__)
 
     @staticmethod
-    def _to_numpy(arg: Union[np.ndarray, SklearnOutlierDetectorOutput]) -> Union[np.ndarray, Dict[str, np.ndarray]]:
-        """Map arg to the frontend format.
+    def _to_frontend_dtype(
+            arg: Union[np.ndarray, SklearnOutlierDetectorOutput]
+            ) -> Union[np.ndarray, Dict[str, np.ndarray]]:
+        """Converts input to frontend data format.
 
-        If `arg` is a `SklearnOutlierDetectorOutput` object, we unpack it into a `dict` and return it.
+        This is an interface method that ensures that the output of the outlier detector is in a common format for
+        different backends. If `arg` is a `SklearnOutlierDetectorOutput` object, we unpack it into a `dict` and
+        return it.
 
         Parameters
         ----------
@@ -100,11 +104,11 @@ class SklearnOutlierDetector(FitMixinSklearn, ABC):
         return arg
 
     @staticmethod
-    def _to_tensor(x: Union[List, np.ndarray]) -> np.ndarray:
-        """Converts the data to a tensor.
+    def _to_backend_dtype(x: Union[List, np.ndarray]) -> np.ndarray:
+        """Converts data from the frontend to the backend format.
 
-        This function is for interface compatibility with the other backends. As such it does nothing but
-        return the input.
+        This is an interface method that ensures that the input of the chosen outlier detector backend is in the correct
+        format. In the case of the Sklearn backend, we ensure the data is a numpy array.
 
         Parameters
         ----------


### PR DESCRIPTION
## What is this:

FIxes #812. Renames `_to_tensor` and `_to_numpy` methods on the base Sklearn and PyTorch backend classes to `_to_frontend_dtype` and `_to_backend_dtype`. Also expands there docstrings.