### PR TITLE
Run Windows and MacOS CI on Python 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,9 @@ jobs:
         python-version: [ '3.8', '3.9', '3.10', '3.11']
         include: # Run macos and windows tests on only one python version
           - os: windows-latest
-            python-version: '3.9'  # PyTorch doesn't yet have 3.10 support on Windows (https://pytorch.org/get-started/locally/#windows-python)
+            python-version: '3.11'
           - os: macos-latest
-            python-version: '3.9'  # Don't test python3.10 for macos (see https://github.com/orgs/community/discussions/38364 for details)
+            python-version: '3.11'
 
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,9 @@ jobs:
         python-version: [ '3.8', '3.9', '3.10', '3.11']
         include: # Run macos and windows tests on only one python version
           - os: windows-latest
-            python-version: '3.11'
+            python-version: '3.10' # torch 1.x not available on Windows or MacOS for Python 3.11
           - os: macos-latest
-            python-version: '3.11'
+            python-version: '3.10'
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Seems that `torch` support is there and since we only run one version on each non-linux platform we might as well run on the latest supported.

Will keep an eye if the MacOS infinite runtime still persists on 3.11.