### PR TITLE
Split tox ci job into seperate jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,4 +169,4 @@ jobs:
       - name: Check optional dependency imports are protected
         run: |
           pip install "tox>=3.21.0,<4.0.0"
-          tox -e ${{env}}
+          tox -e ${{matrix.env}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        env: [ 'prophet', 'tensorflow', 'pytorch ', 'keops', 'pykeops' ]
+        env: [ 'default', 'tensorflow', 'torch', 'prophet', 'keops', 'all' ]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python 3.x

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,9 @@ jobs:
 
   optional_dependencies:
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        env: [ 'prophet', 'tensorflow', 'pytorch ', 'keops', 'pykeops' ]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python 3.x
@@ -167,4 +169,4 @@ jobs:
       - name: Check optional dependency imports are protected
         run: |
           pip install "tox>=3.21.0,<4.0.0"
-          tox
+          tox -e ${{env}}


### PR DESCRIPTION
## What is this

Github ci runner machines are running out of space during the optional dependency tests due to the size of tox environments. To resolve we run each optional dependency tox env in a separate ci job.
