### PR TITLE
Remove deprecated multichannel keyword from `skimage.filters.gaussian`

### DIFF
--- a/alibi_detect/utils/perturbation.py
+++ b/alibi_detect/utils/perturbation.py
@@ -561,8 +561,7 @@ def zoom_blur(x: np.ndarray, max_zoom: float, step_zoom: float, xrange: tuple = 
         return x_z
 
 
-def glass_blur(x: np.ndarray, sigma: float, max_delta: int, iterations: int,
-               channel_axis: int = -1, xrange: tuple = None) -> np.ndarray:
+def glass_blur(x: np.ndarray, sigma: float, max_delta: int, iterations: int, xrange: tuple = None) -> np.ndarray:
     """
     Apply glass blur.
 
@@ -576,8 +575,6 @@ def glass_blur(x: np.ndarray, sigma: float, max_delta: int, iterations: int,
         Maximum pixel range for the blurring.
     iterations
         Number of blurring iterations.
-    channel_axis
-        Denotes the axis of the colour channel. If `None` the image is assumed to be grayscale.
     xrange
         Tuple with min and max data range.
 
@@ -593,14 +590,14 @@ def glass_blur(x: np.ndarray, sigma: float, max_delta: int, iterations: int,
     if xrange[0] != 0 or xrange[1] != 255:
         x = (x - xrange[0]) / (xrange[1] - xrange[0]) * 255
 
-    x = gaussian(x, sigma=sigma, channel_axis=channel_axis).astype(np.uint8)
+    x = gaussian(x, sigma=sigma, channel_axis=-1).astype(np.uint8)  # assume [h, w, c] image layout
     for i in range(iterations):
         for h in range(nrows - max_delta, max_delta, -1):
             for w in range(ncols - max_delta, max_delta, -1):
                 dx, dy = np.random.randint(-max_delta, max_delta, size=(2,))
                 h_prime, w_prime = h + dy, w + dx
                 x[h, w], x[h_prime, w_prime] = x[h_prime, w_prime], x[h, w]
-    x_gb = gaussian(x / 255, sigma=sigma, channel_axis=channel_axis)
+    x_gb = gaussian(x / 255, sigma=sigma, channel_axis=-1)
     x_gb = x_gb * (xrange[1] - xrange[0]) + xrange[0]
     if isinstance(xrange, tuple):
         return np.clip(x_gb, xrange[0], xrange[1])

--- a/alibi_detect/utils/perturbation.py
+++ b/alibi_detect/utils/perturbation.py
@@ -476,7 +476,7 @@ def impulse_noise(x: np.ndarray, amount: float, xrange: tuple = None) -> np.ndar
 
 
 # Blur
-def gaussian_blur(x: np.ndarray, sigma: float, multichannel: bool = True, xrange: tuple = None) -> np.ndarray:
+def gaussian_blur(x: np.ndarray, sigma: float, channel_axis: int = -1, xrange: tuple = None) -> np.ndarray:
     """
     Apply Gaussian blur.
 
@@ -486,8 +486,8 @@ def gaussian_blur(x: np.ndarray, sigma: float, multichannel: bool = True, xrange
         Instance to be perturbed.
     sigma
         Standard deviation determining the strength of the blur.
-    multichannel
-        Whether the image contains multiple channels (RGB) or not.
+    channel_axis
+        Denotes the axis of the colour channel. If `None` the image is assumed to be grayscale.
     xrange
         Tuple with min and max data range.
 
@@ -496,7 +496,7 @@ def gaussian_blur(x: np.ndarray, sigma: float, multichannel: bool = True, xrange
     Perturbed instance.
     """
     x, scale_back = scale_minmax(x, xrange)
-    x_gb = gaussian(x, sigma=sigma, multichannel=multichannel)
+    x_gb = gaussian(x, sigma=sigma, channel_axis=channel_axis)
     if scale_back:
         x_gb = x_gb * (xrange[1] - xrange[0]) + xrange[0]
     if isinstance(xrange, tuple):
@@ -561,7 +561,8 @@ def zoom_blur(x: np.ndarray, max_zoom: float, step_zoom: float, xrange: tuple = 
         return x_z
 
 
-def glass_blur(x: np.ndarray, sigma: float, max_delta: int, iterations: int, xrange: tuple = None) -> np.ndarray:
+def glass_blur(x: np.ndarray, sigma: float, max_delta: int, iterations: int,
+               channel_axis: int = -1, xrange: tuple = None) -> np.ndarray:
     """
     Apply glass blur.
 
@@ -575,6 +576,8 @@ def glass_blur(x: np.ndarray, sigma: float, max_delta: int, iterations: int, xra
         Maximum pixel range for the blurring.
     iterations
         Number of blurring iterations.
+    channel_axis
+        Denotes the axis of the colour channel. If `None` the image is assumed to be grayscale.
     xrange
         Tuple with min and max data range.
 
@@ -590,14 +593,14 @@ def glass_blur(x: np.ndarray, sigma: float, max_delta: int, iterations: int, xra
     if xrange[0] != 0 or xrange[1] != 255:
         x = (x - xrange[0]) / (xrange[1] - xrange[0]) * 255
 
-    x = gaussian(x, sigma=sigma, multichannel=True).astype(np.uint8)
+    x = gaussian(x, sigma=sigma, channel_axis=channel_axis).astype(np.uint8)
     for i in range(iterations):
         for h in range(nrows - max_delta, max_delta, -1):
             for w in range(ncols - max_delta, max_delta, -1):
                 dx, dy = np.random.randint(-max_delta, max_delta, size=(2,))
                 h_prime, w_prime = h + dy, w + dx
                 x[h, w], x[h_prime, w_prime] = x[h_prime, w_prime], x[h, w]
-    x_gb = gaussian(x / 255, sigma=sigma, multichannel=True)
+    x_gb = gaussian(x / 255, sigma=sigma, channel_axis=channel_axis)
     x_gb = x_gb * (xrange[1] - xrange[0]) + xrange[0]
     if isinstance(xrange, tuple):
         return np.clip(x_gb, xrange[0], xrange[1])

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
         "Pillow>=5.4.1, <11.0.0",
         "opencv-python>=3.2.0, <5.0.0",
         "scipy>=1.3.0, <2.0.0",
-        'scikit-image>=0.14.2, !=0.17.1, <0.23',  # https://github.com/SeldonIO/alibi/issues/215
+        'scikit-image>=0.19, <0.23',
         "scikit-learn>=0.20.2, <2.0.0",
         "transformers>=4.0.0, <5.0.0",
         "dill>=0.3.0, <0.4.0",


### PR DESCRIPTION
Fixes #856.

`channel_axis` was introduced in 0.19 so bumping lower bound for `scikit-image` to that.