### PR TITLE
Fix to ensure older tensorflow versions still work

### DIFF
--- a/alibi_detect/saving/_tensorflow/loading.py
+++ b/alibi_detect/saving/_tensorflow/loading.py
@@ -130,7 +130,7 @@ def load_kernel_config(cfg: dict) -> Callable:
     return kernel
 
 
-def load_optimizer(cfg: dict) -> Union[Type[tf.keras.optimizers.Optimizer], tf.keras.optimizers.Optimizer]:
+def load_optimizer(cfg: dict) -> Union[Type['tf.keras.optimizers.Optimizer'], 'tf.keras.optimizers.Optimizer']:
     """
     Loads a TensorFlow optimzier from a optimizer config dict.
 

--- a/alibi_detect/saving/_tensorflow/saving.py
+++ b/alibi_detect/saving/_tensorflow/saving.py
@@ -158,7 +158,7 @@ def save_embedding_config(embed: TransformerEmbedding,
     return cfg_embed
 
 
-def save_optimizer_config(optimizer: Union[tf.keras.optimizers.Optimizer, tf.keras.optimizers.legacy.Optimizer]):
+def save_optimizer_config(optimizer: Union['tf.keras.optimizers.Optimizer', 'tf.keras.optimizers.legacy.Optimizer']):
     """
 
     Parameters


### PR DESCRIPTION
Changing two type annotations for `tf.keras.optimizers.legacy.Optimizer` to forward references since `tf.keras.optimizers.legacy` doesn't exist in older (<2.9?) tensorflow versions. This resulted in the following error:

```
>>> from alibi_detect.saving import save_detector
AttributeError: module 'tensorflow.keras.optimizers' has no attribute 'legacy'
```

We could define new type aliases like `OptimizersTF` in `alibi_detect/utils/_types.py`, but it seems to be overly complicating things to me (we'd need three groups, one containing classes only, one types only, and one containing both...). We're also already using forwardref's for the tensorflow optimizers in other places...

P.s. have tested this with `tensorflow == 2.8` and the error no longer occurs (when it does with `master`).