### PR TITLE
Add abbreviations in the getting_started page

### DIFF
--- a/doc/source/overview/getting_started.md
+++ b/doc/source/overview/getting_started.md
@@ -234,6 +234,10 @@ To get a list of respectively the latest outlier, adversarial and drift detectio
 
 ```python
 import alibi_detect
+```
+
+```python
+# View all the Outlier Detection (od) algorithms available
 alibi_detect.od.__all__
 ```
 
@@ -251,6 +255,7 @@ alibi_detect.od.__all__
 ```
 
 ```python
+# View all the Adversarial Detection (ad) algorithms available
 alibi_detect.ad.__all__
 ```
 
@@ -260,6 +265,7 @@ alibi_detect.ad.__all__
 ```
 
 ```python
+# View all the Concept Drift (cd) detection algorithms available
 alibi_detect.cd.__all__
 ```
 


### PR DESCRIPTION

**Summary:**
This pull request aims to improve the documentation by adding comments to clarify the abbreviations used in getting started page. The goal is to make it more accessible to new users who may not be familiar with these abbreviations.

**Changes Made:**
- Added descriptive comments to the sections listing Outlier Detection (od), Adversarial Detection (ad), and Concept Drift Detection (cd) algorithms. These comments help users understand the meaning of the abbreviations and the purpose of each section.

**Why is this change needed?**
The current documentation uses abbreviations (od, ad, cd) to represent these sections, which might not be immediately clear to new users. By adding these comments, we aim to enhance the user experience and make the documentation more user-friendly.
