### PR TITLE
build: Update maintainers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,5 +7,4 @@ updates:
   open-pull-requests-limit: 10
   reviewers:
     - "jklaise"
-    - "ascillitoe"
     - "mauicv"


### PR DESCRIPTION
Reflects the current organisation [1].

[1] https://github.com/SeldonIO/alibi-detect/pull/875#issuecomment-1899885498
