### PR TITLE
test: Add Pydantic version to matrix variable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Test with pytest
         run: |
           pytest --randomly-seed=0 alibi_detect
-          # Note: The pytest-randomly seed is fixed at 0 for now. Once the legacy np.random.seed(0)'s 
+          # Note: The pytest-randomly seed is fixed at 0 for now. Once the legacy np.random.seed(0)'s
           # are removed from tests, this can be removed, allowing all tests to use random seeds.
 
       - name: Upload coverage to Codecov


### PR DESCRIPTION
This is a follow-up to where the Pydantic v1 shim was added [1]. It's inspired by Ray's approach [2].

This locks the version in the CI and I think that's okay since we don't need to keep on updating them, as they're intended as smoke tests.

[1] https://github.com/SeldonIO/alibi-detect/pull/882#discussion_r1575971961
[2] https://github.com/ray-project/ray/pull/40451
