### PR TITLE
test increase buffer size for latex build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ build_latex: ## Build the documentation into a pdf
 	# explicit cd here due to a bug in latexmk 4.41
 	python -m sphinx -b latex -d doc/_build/doctrees -D language=en doc/source doc/_build/latex && \
 	cd doc/_build/latex && \
-	latexmk -pdf -f -dvi- -ps- -jobname=alibi-detect -interaction=nonstopmode
+	buf_size=300000 latexmk -pdf -f -dvi- -ps- -jobname=alibi-detect -interaction=nonstopmode
 
 .PHONY: clean_docs
 clean_docs: ## Clean the documentation build


### PR DESCRIPTION
# What is this

during the CI, `Latexmk` fails when compiling the pdf version of our docs due to the following error:

```sh
! Unable to read an entire line---bufsize=200000.
Please increase buf_size in texmf.cnf.
``` 

This PR tests setting `buf_size` in the make file containg the compile command. 