### PR TITLE
Add EPSILON to amp for numerical stability for division

### DIFF
--- a/alibi_detect/od/sr.py
+++ b/alibi_detect/od/sr.py
@@ -248,7 +248,8 @@ class SpectralResidual(BaseDetector, ThresholdMixin):
 
         fft = np.fft.fft(X)
         amp = np.abs(fft)
-        log_amp = np.log(amp)
+        # For numerical stability for division to prevent divide by zero being encountered add EPSILON
+        log_amp = np.log(amp + EPSILON)
         phase = np.angle(fft)
         # split spectrum into bias term and symmetric frequencies
         bias, sym_freq = log_amp[:1], log_amp[1:]


### PR DESCRIPTION
There are times when the amp does contain 0s.  The addition of the EPSILON to amp prevents divide by zero being encountered and allows the algorithm to run and return results when the amp does contain 0s.

```
RuntimeWarning: divide by zero encountered in log
  log_amp = np.log(amp)
RuntimeWarning: invalid value encountered in subtract
  res_amp = log_amp - ma_log_amp
```
