### PR TITLE
Replaced eigvals with subset_by_index

### DIFF
--- a/alibi_detect/od/mahalanobis.py
+++ b/alibi_detect/od/mahalanobis.py
@@ -269,7 +269,7 @@ class Mahalanobis(BaseDetector, FitMixin, ThresholdMixin):
         cov_batch = (n - 1.) / (n + max(1, n_batch - 1.)) * self.C + 1. / (n + max(1, n_batch - 1.)) * B.sum(axis=0)
 
         # PCA
-        eigvals, eigvects = eigh(cov_batch, eigvals=(n_params - n_components, n_params - 1))
+        _, eigvects = eigh(cov_batch, subset_by_index=(n_params - n_components, n_params - 1))
 
         # projections
         proj_x = np.matmul(X, eigvects)

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
         "pandas>=1.0.0, <3.0.0",
         "Pillow>=5.4.1, <11.0.0",
         "opencv-python>=3.2.0, <5.0.0",
-        "scipy>=1.3.0, <2.0.0",
+        "scipy>=1.5.0, <2.0.0",
         'scikit-image>=0.19, <0.23',
         "scikit-learn>=0.20.2, <2.0.0",
         "transformers>=4.0.0, <5.0.0",


### PR DESCRIPTION
Replaced `eigvals` with `subset_by_index`. Changed happended in `scipy 1.5.0` (see release notes [here](https://github.com/scipy/scipy/releases/tag/v1.5.0))