### PR TITLE
fix: correct typos 'seperated' and 'occured' in docstrings

### DIFF
--- a/alibi_detect/cd/pytorch/spot_the_diff.py
+++ b/alibi_detect/cd/pytorch/spot_the_diff.py
@@ -44,7 +44,7 @@ class SpotTheDiffDriftTorch:
     ) -> None:
         """
         Classifier-based drift detector with a classifier of form y = a + b_1*k(x,w_1) + ... + b_J*k(x,w_J),
-        where k is a kernel and w_1,...,w_J are learnable test locations. If drift has occured the test locations
+        where k is a kernel and w_1,...,w_J are learnable test locations. If drift has occurred the test locations
         learn to be more/less (given by sign of b_i) similar to test instances than reference instances.
         The test locations are regularised to be close to the average reference instance such that the **difference**
         is then interpretable as the transformation required for each feature to make the average instance more/less

--- a/alibi_detect/cd/spot_the_diff.py
+++ b/alibi_detect/cd/spot_the_diff.py
@@ -46,7 +46,7 @@ class SpotTheDiffDrift(DriftConfigMixin):
     ) -> None:
         """
         Classifier-based drift detector with a classifier of form y = a + b_1*k(x,w_1) + ... + b_J*k(x,w_J),
-        where k is a kernel and w_1,...,w_J are learnable test locations. If drift has occured the test locations
+        where k is a kernel and w_1,...,w_J are learnable test locations. If drift has occurred the test locations
         learn to be more/less (given by sign of b_i) similar to test instances than reference instances.
         The test locations are regularised to be close to the average reference instance such that the **difference**
         is then interpretable as the transformation required for each feature to make the average instance more/less

--- a/alibi_detect/cd/tensorflow/spot_the_diff.py
+++ b/alibi_detect/cd/tensorflow/spot_the_diff.py
@@ -39,7 +39,7 @@ class SpotTheDiffDriftTF:
     ) -> None:
         """
         Classifier-based drift detector with a classifier of form y = a + b_1*k(x,w_1) + ... + b_J*k(x,w_J),
-        where k is a kernel and w_1,...,w_J are learnable test locations. If drift has occured the test locations
+        where k is a kernel and w_1,...,w_J are learnable test locations. If drift has occurred the test locations
         learn to be more/less (given by sign of b_i) similar to test instances than reference instances.
         The test locations are regularised to be close to the average reference instance such that the **difference**
         is then interpretable as the transformation required for each feature to make the average instance more/less

--- a/alibi_detect/utils/frameworks.py
+++ b/alibi_detect/utils/frameworks.py
@@ -40,7 +40,7 @@ HAS_BACKEND = {
 
 
 def _iter_to_str(iterable: Iterable[str]) -> str:
-    """ Correctly format iterable of items to comma seperated sentence string."""
+    """ Correctly format iterable of items to comma separated sentence string."""
     items = [f'`{option}`' for option in iterable]
     last_item_str = f'{items[-1]}' if not items[:-1] else f' and {items[-1]}'
     return ', '.join(items[:-1]) + last_item_str


### PR DESCRIPTION
Corrected minor typos in docstrings:

- `seperated` → `separated` in `frameworks.py`
- `occured` → `occurred` in `spot_the_diff.py` (core, tensorflow, and pytorch modules)

No functional changes.