### PR TITLE
Fix fetch_tf_model download path handling for newer Keras versions

### DIFF
--- a/alibi_detect/utils/fetching/fetching.py
+++ b/alibi_detect/utils/fetching/fetching.py
@@ -94,7 +94,12 @@ def fetch_tf_model(dataset: str, model: str) -> tf.keras.Model:
     """
     url = 'https://storage.googleapis.com/seldon-models/alibi-detect/classifier/'
     path_model = _join_url(url, [dataset, model, 'model.h5'])
-    save_path = tf.keras.utils.get_file(Path(model + '.h5').resolve(), path_model)
+    save_path = tf.keras.utils.get_file(
+        fname=model + ".h5",
+        origin=path_model,
+        cache_dir=Path.cwd(),
+        cache_subdir="",
+    )
     if dataset == 'cifar10' and model == 'resnet56':
         custom_objects = {'backend': backend}
     else:

--- a/alibi_detect/utils/tests/test_fetching.py
+++ b/alibi_detect/utils/tests/test_fetching.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from alibi_detect.utils.fetching import fetch_tf_model
+
+
+@patch("alibi_detect.utils.fetching.fetching.tf.keras.models.load_model")
+@patch("alibi_detect.utils.fetching.fetching.tf.keras.utils.get_file")
+def test_fetch_tf_model_uses_filename_and_cache_dir(
+    mock_get_file: MagicMock,
+    mock_load_model: MagicMock,
+) -> None:
+    mock_get_file.return_value = "/tmp/resnet32.h5"
+
+    fetch_tf_model("cifar10", "resnet32")
+
+    mock_get_file.assert_called_once()
+
+    _, kwargs = mock_get_file.call_args
+
+    assert kwargs["fname"] == "resnet32.h5"
+    assert kwargs["cache_dir"] == Path.cwd()
+    assert kwargs["cache_subdir"] == ""
+    assert "origin" in kwargs
+
+    mock_load_model.assert_called_once()
+
+    args, kwargs = mock_load_model.call_args
+
+    assert args[0] == "/tmp/resnet32.h5"
+    assert kwargs["custom_objects"] is None


### PR DESCRIPTION
## Summary

This PR fixes `fetch_tf_model` when used with newer versions of Keras.

Recent versions of Keras no longer accept a full path passed through the `fname` argument of `tf.keras.utils.get_file`. Instead, the filename must be provided via `fname`, while the destination directory is specified using `cache_dir`.

This change updates `fetch_tf_model` accordingly, preserving the existing download location while resolving the `get_file` path error raised by newer Keras releases.

## Changes

* Pass only the filename to `tf.keras.utils.get_file`.
* Specify the download directory using `cache_dir`.
* Add a regression test verifying that `fetch_tf_model` calls `get_file` with the expected arguments.

## Testing

* Added a mocked regression test for `fetch_tf_model`.
* Verified that the new test passes locally.
* Confirmed that the original `ValueError` reported in issue #936 is resolved.


Closes #936
