### PR TITLE
Import `Literal`, `Protocol` and `runtime_checkable` from `typing`

### DIFF
--- a/alibi_detect/base.py
+++ b/alibi_detect/base.py
@@ -3,8 +3,7 @@ import os
 import copy
 import json
 import numpy as np
-from typing import Dict, Any, Optional, Union
-from typing_extensions import Protocol, runtime_checkable
+from typing import Dict, Any, Optional, Protocol, Union, runtime_checkable
 from alibi_detect.version import __version__
 
 

--- a/alibi_detect/exceptions.py
+++ b/alibi_detect/exceptions.py
@@ -1,6 +1,5 @@
 """This module defines the Alibi Detect exception hierarchy and common exceptions used across the library."""
-from typing_extensions import Literal
-from typing import Callable
+from typing import Callable, Literal
 from abc import ABC
 from functools import wraps
 

--- a/alibi_detect/od/_knn.py
+++ b/alibi_detect/od/_knn.py
@@ -1,5 +1,4 @@
-from typing import Callable, Union, Optional, Dict, Any, List, Tuple
-from typing_extensions import Literal
+from typing import Callable, Union, Optional, Dict, Any, List, Literal, Tuple
 
 import numpy as np
 

--- a/alibi_detect/od/_lof.py
+++ b/alibi_detect/od/_lof.py
@@ -1,5 +1,4 @@
-from typing import Callable, Union, Optional, Dict, Any, List, Tuple
-from typing_extensions import Literal
+from typing import Callable, Union, Optional, Dict, Any, List, Literal, Tuple
 
 import numpy as np
 

--- a/alibi_detect/od/_mahalanobis.py
+++ b/alibi_detect/od/_mahalanobis.py
@@ -1,6 +1,5 @@
-from typing import Dict, Any
+from typing import Dict, Any, Literal
 from alibi_detect.exceptions import _catch_error as catch_error
-from typing_extensions import Literal
 
 import numpy as np
 

--- a/alibi_detect/od/_pca.py
+++ b/alibi_detect/od/_pca.py
@@ -1,5 +1,4 @@
-from typing import Union, Optional, Callable, Dict, Any
-from typing_extensions import Literal
+from typing import Union, Optional, Callable, Dict, Any, Literal
 
 import numpy as np
 

--- a/alibi_detect/od/base.py
+++ b/alibi_detect/od/base.py
@@ -1,7 +1,6 @@
 from alibi_detect.utils.missing_optional_dependency import import_optional
 
-from typing import Union
-from typing_extensions import Literal, Protocol, runtime_checkable
+from typing import Literal, Protocol, Union, runtime_checkable
 
 
 # Use Protocols instead of base classes for the backend associated objects. This is a bit more flexible and allows us to

--- a/alibi_detect/utils/_types.py
+++ b/alibi_detect/utils/_types.py
@@ -3,11 +3,10 @@ Defining types compatible with different Python versions and defining custom typ
 """
 from sklearn.base import BaseEstimator  # import here (instead of later) since sklearn currently a core dep
 from alibi_detect.utils.frameworks import has_tensorflow, has_pytorch
-from typing import Union, Type, Optional
+from typing import Union, Type, Optional, Literal
 
 
-# Literal for typing
-from typing_extensions import Literal
+# TypeAlias is only available in typing from Python 3.10, so import from typing_extensions for now
 from typing_extensions import TypeAlias
 
 


### PR DESCRIPTION
Closes #838.

Now that the minimum supported Python version is 3.9 (`python_requires=">=3.9"` in `setup.py`), `Literal`, `Protocol` and `runtime_checkable` are all available from the standard library `typing` module — they were added in 3.8 — so there is no need to source them from `typing_extensions`.

### Changes

| File | Moved to `typing` |
|---|---|
| `alibi_detect/base.py` | `Protocol`, `runtime_checkable` |
| `alibi_detect/exceptions.py` | `Literal` |
| `alibi_detect/od/base.py` | `Literal`, `Protocol`, `runtime_checkable` |
| `alibi_detect/od/_knn.py` | `Literal` |
| `alibi_detect/od/_lof.py` | `Literal` |
| `alibi_detect/od/_mahalanobis.py` | `Literal` |
| `alibi_detect/od/_pca.py` | `Literal` |
| `alibi_detect/utils/_types.py` | `Literal` |

### What is deliberately left alone

The `typing-extensions` dependency in `setup.py` is **retained**, as two imports still require it under Python 3.9:

- `TypeAlias` in `alibi_detect/utils/_types.py` — only in `typing` from **3.10**
- `Self` in `alibi_detect/od/pytorch/ensemble.py`, `alibi_detect/od/pytorch/svm.py` and `alibi_detect/od/sklearn/base.py` — only in `typing` from **3.11**

The now-inaccurate `# Literal for typing` comment in `_types.py` has been updated to explain why `TypeAlias` is still imported from `typing_extensions`.

### Testing

- `flake8` clean on all changed files.
- `mypy` reports no new errors in the changed files.
- Verified `runtime_checkable` `isinstance()` checks against `TransformProtocol` still behave correctly after moving `Protocol` to `typing`, and that the `Literal`-annotated detector constructors (`KNN`, `PCA`) still fit and predict.
- `alibi_detect/od/tests/test_mahalanobis.py` (128 passed), `test_iforest.py`, `test_sr.py`, `test_ensemble.py` (33 passed) all pass locally.

Note that the `test__knn`, `test__lof`, `test__pca`, `test__mahalanobis`, `test__gmm` and `test__svm` suites are skipped at module level on `master` (see #810), so they did not exercise these changes; the behaviour above was verified manually instead.