### PR TITLE
fix: correct off-by-one and tie handling in od p-value computation

### DIFF
--- a/alibi_detect/od/pytorch/base.py
+++ b/alibi_detect/od/pytorch/base.py
@@ -196,7 +196,7 @@ class TorchOutlierDetector(torch.nn.Module, FitMixinTorch, ABC):
         -------
         `torch.Tensor` or ``None``
         """
-        return (1 + (scores[:, None] < self.val_scores).sum(-1))/len(self.val_scores) \
+        return (1 + (scores[:, None] <= self.val_scores).sum(-1))/(len(self.val_scores) + 1) \
             if self.threshold_inferred else None
 
     def infer_threshold(self, x: torch.Tensor, fpr: float):

--- a/alibi_detect/od/sklearn/base.py
+++ b/alibi_detect/od/sklearn/base.py
@@ -145,7 +145,7 @@ class SklearnOutlierDetector(FitMixinSklearn, ABC):
         -------
         `np.ndarray` or ``None``
         """
-        return (1 + (scores[:, None] < self.val_scores).sum(-1))/len(self.val_scores) \
+        return (1 + (scores[:, None] <= self.val_scores).sum(-1))/(len(self.val_scores) + 1) \
             if self.threshold_inferred else None
 
     def infer_threshold(self, x: np.ndarray, fpr: float) -> None:


### PR DESCRIPTION
Fixes #958

## What

`od/pytorch/base.py:199` and `od/sklearn/base.py:148` compute the outlier
p-value as

```python
return (1 + (scores[:, None] < self.val_scores).sum(-1))/len(self.val_scores) \
    if self.threshold_inferred else None
```

`od/pytorch/ensemble.py:114`, same author, same subpackage, computes the
same "add one to the count the test score beats" idea but divides by
`len(self.val_scores) + 1`:

```python
p_vals = (1 + less_than_val_scores.sum(1))/(len(self.val_scores) + 1)
```

The `base.py` denominator can push the value above 1. Reproduced through
the public API (0.13.0 wheel, Python 3.11, numpy 1.26.4):

```python
>>> d = GMM(n_components=1, backend='sklearn')
>>> d.fit(X_fit)          # X_fit as in the linked issue
>>> d.infer_threshold(X_cal, fpr=0.5)   # len(val_scores) == 4
>>> d.predict(np.array([[3.5]], dtype=np.float32))['data']['p_value']
array([1.25])
```

The same line's strict `<` separately collapses tied scores toward `1/n`
instead of `1`. Full numbers, and the exact-rational tie-support sweep,
are in #958.

## Fix

One line changed per file: `<` becomes `<=`, and the denominator becomes
`len(self.val_scores) + 1`, matching `ensemble.py`.

```python
return (1 + (scores[:, None] <= self.val_scores).sum(-1))/(len(self.val_scores) + 1) \
    if self.threshold_inferred else None
```

Verified against the patched files:

```python
>>> s.val_scores = np.full(9, 5.0); s._p_vals(np.array([5.0]))
array([1.])
>>> s.val_scores = np.array([1.0,2.0,3.0,4.0]); s._p_vals(np.array([0.0]))
array([1.])
```

I searched `od/pytorch/tests` and `od/sklearn/tests` for coverage of this
expression and found none, so this is a pure two-line change with nothing
else to update. `ensemble.py:114` is untouched; its denominator is already
correct and its strict comparator is a separate, package-wide question
I've left out of this PR (noted in #958).